### PR TITLE
Support querying annotation markers

### DIFF
--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -223,7 +223,9 @@ class QueryMetrics:
                 break
 
         if self.marker:
-            results = self.query_range("rmsjob_annotations{$job,$marker}>0", self.start_time, self.end_time, QueryMetrics.SCAN_STEP)
+            results = self.query_range(
+                "rmsjob_annotations{$job,$marker}>0", self.start_time, self.end_time, QueryMetrics.SCAN_STEP
+            )
             if len(results) > 0:
                 self.start_time = datetime.fromtimestamp(results[0]["values"][0][0])
                 self.end_time = datetime.fromtimestamp(results[0]["values"][-1][0])
@@ -249,15 +251,11 @@ class QueryMetrics:
         # Force max lookback for more accurate results
         lookback = self.interval * 2
 
-        results = self.query_range(
-            query, start_window[0], start_window[1], self.interval, lookback
-        )
+        results = self.query_range(query, start_window[0], start_window[1], self.interval, lookback)
         if len(results) > 0:
             self.start_time = datetime.fromtimestamp(results[0]["values"][0][0])
 
-        results = self.query_range(
-            query, end_window[0], end_window[1], self.interval, lookback
-        )
+        results = self.query_range(query, end_window[0], end_window[1], self.interval, lookback)
         if len(results) > 0:
             self.end_time = datetime.fromtimestamp(results[0]["values"][-1][0])
 
@@ -555,9 +553,7 @@ class QueryMetrics:
                 % (self.jobStep, self.num_nodes_step, self.num_nodes_job)
             )
         if self.marker:
-            print(
-                "** Report confined to annotation marker=%s" % (self.marker)
-            )
+            print("** Report confined to annotation marker=%s" % (self.marker))
         print("-" * 70)
         print("")
         print("Job Overview (Num Nodes = %i, Machine = %s)" % (len(self.hosts), system))

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -788,6 +788,10 @@ class QueryMetrics:
             ptext = """<strong>Job Step Mode</strong>: Report confined to job step = %s""" % (self.jobStep)
             Story.append(Paragraph(ptext))
             Story.append(HRFlowable(width="100%", thickness=2))
+        if self.marker:
+            ptext = """<strong>Annotation Mode</strong>: Report confined to marker = %s""" % (self.marker)
+            Story.append(Paragraph(ptext))
+            Story.append(HRFlowable(width="100%", thickness=2))
 
         # generate Utilization Table
         Story.append(Spacer(1, 0.2 * inch))


### PR DESCRIPTION
This PR enables selection of specific annotation markers with the query tool.

Existing job/jobstep queries remain unchanged, but when the `--marker` flag is set, the tool will perform an additional query to find an annotation with the given marker text and update the time range accordingly. If the given marker can't be found, execution will end early with an error.

- [x] Marker selection flag.
- [x] Display selected marker in text report.
- [x] Display selected marker in PDF report.

Sample report with marker:
```
----------------------------------------------------------------------
Omnistat Report Card for Job Id: 3566994
** Report confined to annotation marker=sample marker
----------------------------------------------------------------------

Job Overview (Num Nodes = 1, Machine = Test System)
 --> Start time = 2025-07-10 10:31:19
 --> End   time = 2025-07-10 10:34:00
 --> Duration   = 160 secs

GPU Statistics:

           | Utilization (%)  |  Memory Use (%)  | Temperature (C)  |    Power (W)     | Energy (kWh) |
     GPU # |    Max     Mean  |    Max     Mean  |    Max     Mean  |    Max     Mean  |    Total     |
    ---------------------------------------------------------------------------------------------------
         0 |  100.00   87.94  |   56.08   55.96  |   56.00   52.73  |  445.00  431.14  |   2.00e-02   |
         1 |  100.00   88.90  |   56.08   55.96  |   55.00   52.50  |    0.00    0.00  |   0.00e+00   |
         2 |  100.00   86.35  |   56.08   55.96  |   49.00   46.75  |  429.00  418.51  |   1.94e-02   |
         3 |  100.00   89.89  |   56.08   55.96  |   51.00   48.42  |    0.00    0.00  |   0.00e+00   |
         4 |  100.00   89.86  |   56.08   55.96  |   54.00   51.10  |  444.00  429.82  |   1.94e-02   |
         5 |  100.00   86.76  |   56.08   55.96  |   58.00   55.53  |    0.00    0.00  |   0.00e+00   |
         6 |  100.00   90.23  |   56.08   55.96  |   44.00   41.95  |  431.00  420.00  |   1.97e-02   |
         7 |  100.00   85.95  |   56.08   55.96  |   52.00   49.31  |    0.00    0.00  |   0.00e+00   |

Vendor Energy Data:
  -----------------------------------------------------------------
  Approximate Total Memory Energy Consumed = 3.96e-03 kWh ( 4.20 %)
  Approximate Total CPU    Energy Consumed = 3.33e-03 kWh ( 3.53 %)
  Approximate Total Accel  Energy Consumed = 7.84e-02 kWh (83.24 %)
  -----------------------------------------------------------------
  Approximate Total Node Energy Consumed   = 9.42e-02 kWh

--
Query interval = 0.100 secs
Query execution time = 0.6 secs
Version = 1.6.0 (6c80908)
```

Same report without marker:
```
----------------------------------------------------------------------
Omnistat Report Card for Job Id: 3566994
----------------------------------------------------------------------

Job Overview (Num Nodes = 1, Machine = Test System)
 --> Start time = 2025-07-10 10:31:11
 --> End   time = 2025-07-10 10:34:01
 --> Duration   = 170 secs

GPU Statistics:

           | Utilization (%)  |  Memory Use (%)  | Temperature (C)  |    Power (W)     | Energy (kWh) |
     GPU # |    Max     Mean  |    Max     Mean  |    Max     Mean  |    Max     Mean  |    Total     |
    ---------------------------------------------------------------------------------------------------
         0 |  100.00   82.97  |   56.08   53.14  |   56.00   52.10  |  445.00  414.00  |   2.02e-02   |
         1 |  100.00   83.87  |   56.08   53.16  |   55.00   51.87  |    0.00    0.00  |   0.00e+00   |
         2 |  100.00   81.49  |   56.08   53.14  |   49.00   46.29  |  429.00  401.42  |   1.97e-02   |
         3 |  100.00   84.81  |   56.08   53.16  |   51.00   47.93  |    0.00    0.00  |   0.00e+00   |
         4 |  100.00   84.73  |   56.08   53.08  |   54.00   50.45  |  444.00  412.57  |   1.97e-02   |
         5 |  100.00   81.85  |   56.08   53.15  |   58.00   54.90  |    0.00    0.00  |   0.00e+00   |
         6 |  100.00   85.13  |   56.08   53.10  |   44.00   41.50  |  431.00  403.44  |   2.00e-02   |
         7 |  100.00   81.04  |   56.08   53.11  |   52.00   48.86  |    0.00    0.00  |   0.00e+00   |

Vendor Energy Data:
  -----------------------------------------------------------------
  Approximate Total Memory Energy Consumed = 4.19e-03 kWh ( 4.37 %)
  Approximate Total CPU    Energy Consumed = 3.49e-03 kWh ( 3.64 %)
  Approximate Total Accel  Energy Consumed = 7.96e-02 kWh (83.01 %)
  -----------------------------------------------------------------
  Approximate Total Node Energy Consumed   = 9.59e-02 kWh

--
Query interval = 0.100 secs
Query execution time = 0.6 secs
Version = 1.6.0 (6c80908)
```