### PR TITLE
Fix and improve dashboards

### DIFF
--- a/docker/grafana/json-models/job.json
+++ b/docker/grafana/json-models/job.json
@@ -1357,7 +1357,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 393
+            "y": 505
           },
           "id": 88,
           "interval": "$interval",
@@ -1467,7 +1467,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 393
+            "y": 505
           },
           "id": 89,
           "interval": "$interval",
@@ -1617,7 +1617,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 870
+            "y": 982
           },
           "id": 91,
           "interval": "$interval",
@@ -1768,7 +1768,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 878
+            "y": 990
           },
           "id": 99,
           "interval": "$interval",
@@ -1932,7 +1932,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 878
+            "y": 990
           },
           "id": 100,
           "interval": "$interval",
@@ -2081,7 +2081,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 394
+            "y": 506
           },
           "id": 28,
           "interval": "$interval",
@@ -2143,7 +2143,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 394
+            "y": 506
           },
           "id": 86,
           "interval": "$interval",
@@ -2256,7 +2256,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 780
+            "y": 892
           },
           "id": 29,
           "interval": "$interval",
@@ -2318,7 +2318,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 780
+            "y": 892
           },
           "id": 31,
           "interval": "$interval",
@@ -2459,7 +2459,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 788
+            "y": 900
           },
           "id": 24,
           "interval": "$interval",
@@ -2533,7 +2533,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 395
+            "y": 507
           },
           "id": 27,
           "interval": "$interval",
@@ -2643,7 +2643,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 395
+            "y": 507
           },
           "id": 87,
           "interval": "$interval",
@@ -2793,7 +2793,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 406
+            "y": 518
           },
           "id": 90,
           "interval": "$interval",
@@ -2960,7 +2960,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 414
+            "y": 526
           },
           "id": 98,
           "interval": "$interval",
@@ -3140,7 +3140,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 414
+            "y": 526
           },
           "id": 95,
           "interval": "$interval",
@@ -3411,7 +3411,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 423
+            "y": 535
           },
           "id": 52,
           "interval": "$interval",
@@ -3548,7 +3548,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3564,7 +3565,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 585
+            "y": 33
           },
           "id": 142,
           "interval": "$interval",
@@ -3657,7 +3658,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3673,7 +3675,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 593
+            "y": 41
           },
           "id": 33,
           "interval": "$interval",
@@ -3766,7 +3768,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3782,7 +3785,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 601
+            "y": 49
           },
           "id": 128,
           "interval": "$interval",
@@ -3875,7 +3878,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3891,7 +3895,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 609
+            "y": 57
           },
           "id": 129,
           "interval": "$interval",
@@ -3917,14 +3921,14 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance) (rocm_average_socket_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "expr": "sum by (instance) (rocm_average_socket_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
               "instant": false,
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "GPU Power (W)",
+          "title": "Cumulative GPU Power (W)",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -3984,7 +3988,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4000,7 +4005,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 617
+            "y": 65
           },
           "id": 130,
           "interval": "$interval",
@@ -4093,7 +4098,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4109,7 +4115,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 617
+            "y": 65
           },
           "id": 131,
           "interval": "$interval",
@@ -4232,7 +4238,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 799
+            "y": 911
           },
           "id": 143,
           "interval": "$interval",
@@ -4332,7 +4338,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 807
+            "y": 919
           },
           "id": 127,
           "interval": "$interval",
@@ -4432,7 +4438,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 815
+            "y": 927
           },
           "id": 104,
           "interval": "$interval",
@@ -4532,7 +4538,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 823
+            "y": 935
           },
           "id": 22,
           "interval": "$interval",
@@ -4632,7 +4638,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 831
+            "y": 943
           },
           "id": 25,
           "interval": "$interval",
@@ -4732,7 +4738,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 831
+            "y": 943
           },
           "id": 23,
           "interval": "$interval",
@@ -4830,8 +4836,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4847,7 +4852,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 219
+            "y": 331
           },
           "id": 144,
           "interval": "$interval",
@@ -4940,8 +4945,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4957,7 +4961,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 299
+            "y": 411
           },
           "id": 137,
           "interval": "$interval",
@@ -5050,8 +5054,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5067,7 +5070,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 307
+            "y": 419
           },
           "id": 138,
           "interval": "$interval",
@@ -5160,8 +5163,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5177,7 +5179,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 315
+            "y": 427
           },
           "id": 139,
           "interval": "$interval",
@@ -5270,8 +5272,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5287,7 +5288,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 323
+            "y": 435
           },
           "id": 140,
           "interval": "$interval",
@@ -5380,8 +5381,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5397,7 +5397,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 323
+            "y": 435
           },
           "id": 141,
           "interval": "$interval",
@@ -5521,7 +5521,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3791
+            "y": 3903
           },
           "id": 134,
           "interval": "$interval",
@@ -5645,7 +5645,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3030
+            "y": 3142
           },
           "id": 125,
           "interval": "$interval",
@@ -5773,7 +5773,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3751
+            "y": 3863
           },
           "id": 120,
           "options": {
@@ -5969,7 +5969,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3751
+            "y": 3863
           },
           "id": 121,
           "options": {
@@ -6162,8 +6162,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6179,7 +6178,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 280
+            "y": 392
           },
           "id": 105,
           "interval": "$interval",
@@ -6273,8 +6272,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6290,7 +6288,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 280
+            "y": 392
           },
           "id": 106,
           "interval": "$interval",
@@ -6414,7 +6412,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7766
+            "y": 7878
           },
           "id": 116,
           "interval": "$interval",
@@ -6524,7 +6522,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7766
+            "y": 7878
           },
           "id": 117,
           "interval": "$interval",
@@ -6649,7 +6647,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3036
+            "y": 3148
           },
           "id": 135,
           "interval": "$interval",
@@ -6813,7 +6811,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3085
+            "y": 3197
           },
           "id": 56,
           "interval": "$interval",
@@ -7037,7 +7035,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17086
+            "y": 17198
           },
           "id": 107,
           "interval": "$interval",
@@ -7232,7 +7230,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17086
+            "y": 17198
           },
           "id": 112,
           "interval": "$interval",
@@ -7391,7 +7389,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17094
+            "y": 17206
           },
           "id": 108,
           "interval": "$interval",
@@ -7619,7 +7617,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17094
+            "y": 17206
           },
           "id": 113,
           "interval": "$interval",
@@ -7774,7 +7772,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17102
+            "y": 17214
           },
           "id": 109,
           "interval": "$interval",
@@ -8002,7 +8000,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17102
+            "y": 17214
           },
           "id": 115,
           "interval": "$interval",
@@ -8158,7 +8156,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17110
+            "y": 17222
           },
           "id": 110,
           "interval": "$interval",
@@ -8382,7 +8380,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17110
+            "y": 17222
           },
           "id": 114,
           "interval": "$interval",

--- a/docker/grafana/json-models/job.json
+++ b/docker/grafana/json-models/job.json
@@ -1357,7 +1357,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 393
           },
           "id": 88,
           "interval": "$interval",
@@ -1467,7 +1467,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 393
           },
           "id": 89,
           "interval": "$interval",
@@ -1601,8 +1601,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1618,7 +1617,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 507
+            "y": 870
           },
           "id": 91,
           "interval": "$interval",
@@ -1702,8 +1701,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1770,7 +1768,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 515
+            "y": 878
           },
           "id": 99,
           "interval": "$interval",
@@ -1882,8 +1880,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1935,7 +1932,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 515
+            "y": 878
           },
           "id": 100,
           "interval": "$interval",
@@ -2064,8 +2061,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "#EAB839",
@@ -2085,7 +2081,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 31
+            "y": 394
           },
           "id": 28,
           "interval": "$interval",
@@ -2147,7 +2143,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 31
+            "y": 394
           },
           "id": 86,
           "interval": "$interval",
@@ -2240,8 +2236,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "#EAB839",
@@ -2261,7 +2256,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 417
+            "y": 780
           },
           "id": 29,
           "interval": "$interval",
@@ -2323,7 +2318,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 417
+            "y": 780
           },
           "id": 31,
           "interval": "$interval",
@@ -2448,8 +2443,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2465,7 +2459,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 425
+            "y": 788
           },
           "id": 24,
           "interval": "$interval",
@@ -2539,7 +2533,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 395
           },
           "id": 27,
           "interval": "$interval",
@@ -2649,7 +2643,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 395
           },
           "id": 87,
           "interval": "$interval",
@@ -2783,8 +2777,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2800,7 +2793,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 406
           },
           "id": 90,
           "interval": "$interval",
@@ -2884,8 +2877,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2968,7 +2960,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 414
           },
           "id": 98,
           "interval": "$interval",
@@ -3096,8 +3088,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3149,7 +3140,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 414
           },
           "id": 95,
           "interval": "$interval",
@@ -3296,8 +3287,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -3421,7 +3411,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 60
+            "y": 423
           },
           "id": 52,
           "interval": "$interval",
@@ -3558,8 +3548,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3575,7 +3564,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 222
+            "y": 585
           },
           "id": 142,
           "interval": "$interval",
@@ -3668,8 +3657,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3685,7 +3673,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 230
+            "y": 593
           },
           "id": 33,
           "interval": "$interval",
@@ -3778,8 +3766,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3795,7 +3782,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 238
+            "y": 601
           },
           "id": 128,
           "interval": "$interval",
@@ -3888,8 +3875,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3905,7 +3891,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 246
+            "y": 609
           },
           "id": 129,
           "interval": "$interval",
@@ -3998,8 +3984,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4015,7 +4000,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 254
+            "y": 617
           },
           "id": 130,
           "interval": "$interval",
@@ -4108,8 +4093,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4125,7 +4109,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 254
+            "y": 617
           },
           "id": 131,
           "interval": "$interval",
@@ -4232,8 +4216,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4249,7 +4232,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 436
+            "y": 799
           },
           "id": 143,
           "interval": "$interval",
@@ -4333,8 +4316,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4350,7 +4332,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 444
+            "y": 807
           },
           "id": 127,
           "interval": "$interval",
@@ -4434,8 +4416,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4451,7 +4432,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 452
+            "y": 815
           },
           "id": 104,
           "interval": "$interval",
@@ -4551,7 +4532,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 460
+            "y": 823
           },
           "id": 22,
           "interval": "$interval",
@@ -4651,7 +4632,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 468
+            "y": 831
           },
           "id": 25,
           "interval": "$interval",
@@ -4751,7 +4732,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 468
+            "y": 831
           },
           "id": 23,
           "interval": "$interval",
@@ -4866,7 +4847,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 344
+            "y": 219
           },
           "id": 144,
           "interval": "$interval",
@@ -4976,7 +4957,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 352
+            "y": 299
           },
           "id": 137,
           "interval": "$interval",
@@ -5086,7 +5067,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 360
+            "y": 307
           },
           "id": 138,
           "interval": "$interval",
@@ -5179,7 +5160,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5195,7 +5177,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 368
+            "y": 315
           },
           "id": 139,
           "interval": "$interval",
@@ -5288,7 +5270,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5304,7 +5287,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 376
+            "y": 323
           },
           "id": 140,
           "interval": "$interval",
@@ -5397,7 +5380,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5413,7 +5397,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 376
+            "y": 323
           },
           "id": 141,
           "interval": "$interval",
@@ -5537,7 +5521,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3428
+            "y": 3791
           },
           "id": 134,
           "interval": "$interval",
@@ -5661,7 +5645,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2667
+            "y": 3030
           },
           "id": 125,
           "interval": "$interval",
@@ -5789,7 +5773,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3388
+            "y": 3751
           },
           "id": 120,
           "options": {
@@ -5985,7 +5969,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3388
+            "y": 3751
           },
           "id": 121,
           "options": {
@@ -6178,7 +6162,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6194,7 +6179,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6255
+            "y": 280
           },
           "id": 105,
           "interval": "$interval",
@@ -6288,7 +6273,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6304,7 +6290,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6255
+            "y": 280
           },
           "id": 106,
           "interval": "$interval",
@@ -6428,7 +6414,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7403
+            "y": 7766
           },
           "id": 116,
           "interval": "$interval",
@@ -6538,7 +6524,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7403
+            "y": 7766
           },
           "id": 117,
           "interval": "$interval",
@@ -6594,7 +6580,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 132,
       "panels": [
@@ -6663,7 +6649,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2673
+            "y": 3036
           },
           "id": 135,
           "interval": "$interval",
@@ -6720,7 +6706,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 57,
       "panels": [
@@ -6827,7 +6813,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2722
+            "y": 3085
           },
           "id": 56,
           "interval": "$interval",
@@ -6920,7 +6906,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 111,
       "panels": [
@@ -7051,7 +7037,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16723
+            "y": 17086
           },
           "id": 107,
           "interval": "$interval",
@@ -7246,7 +7232,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16723
+            "y": 17086
           },
           "id": 112,
           "interval": "$interval",
@@ -7405,7 +7391,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16731
+            "y": 17094
           },
           "id": 108,
           "interval": "$interval",
@@ -7633,7 +7619,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16731
+            "y": 17094
           },
           "id": 113,
           "interval": "$interval",
@@ -7788,7 +7774,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16739
+            "y": 17102
           },
           "id": 109,
           "interval": "$interval",
@@ -8016,7 +8002,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16739
+            "y": 17102
           },
           "id": 115,
           "interval": "$interval",
@@ -8172,7 +8158,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16747
+            "y": 17110
           },
           "id": 110,
           "interval": "$interval",
@@ -8396,7 +8382,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16747
+            "y": 17110
           },
           "id": 114,
           "interval": "$interval",

--- a/docker/grafana/json-models/job.json
+++ b/docker/grafana/json-models/job.json
@@ -23,7 +23,7 @@
         "hide": false,
         "iconColor": "text",
         "name": "User Annotations",
-        "step": "5s",
+        "step": "$interval",
         "titleFormat": "{{marker}}"
       }
     ]

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -14,7 +14,7 @@ all: $(RMS) $(STANDALONE) $(USER) $(DOCKER)
 
 json-models/system/rms-%.json: source/%.json
 	./scripts/filter-dashboard --input $< \
-		--exclude-metrics rocm_throttle_events omnistat_network \
+		--exclude-metrics rocm_throttle_events omnistat_network omnistat_vendor_ \
 		--replace-name Source:RMS > $@
 
 json-models/system/standalone-%.json: json-models/system/rms-%.json
@@ -32,6 +32,7 @@ json-models/user/global.json: source/global.json
 
 json-models/user/job.json: source/job.json
 	./scripts/filter-dashboard --input $< \
+		--exclude-metrics omnistat_vendor_ \
 		--replace-name Source:User > $@
 
 # The job dashboard used in the local docker-based Grafana is the same as the

--- a/grafana/json-models/system/rms-job.json
+++ b/grafana/json-models/system/rms-job.json
@@ -1764,7 +1764,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 393
+            "y": 505
           },
           "id": 88,
           "interval": "$interval",
@@ -1874,7 +1874,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 393
+            "y": 505
           },
           "id": 89,
           "interval": "$interval",
@@ -2024,7 +2024,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 870
+            "y": 982
           },
           "id": 91,
           "interval": "$interval",
@@ -2175,7 +2175,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 878
+            "y": 990
           },
           "id": 99,
           "interval": "$interval",
@@ -2339,7 +2339,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 878
+            "y": 990
           },
           "id": 100,
           "interval": "$interval",
@@ -2488,7 +2488,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 394
+            "y": 506
           },
           "id": 28,
           "interval": "$interval",
@@ -2550,7 +2550,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 394
+            "y": 506
           },
           "id": 86,
           "interval": "$interval",
@@ -2663,7 +2663,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 780
+            "y": 892
           },
           "id": 29,
           "interval": "$interval",
@@ -2725,7 +2725,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 780
+            "y": 892
           },
           "id": 31,
           "interval": "$interval",
@@ -2866,7 +2866,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 788
+            "y": 900
           },
           "id": 24,
           "interval": "$interval",
@@ -2940,7 +2940,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 395
+            "y": 507
           },
           "id": 27,
           "interval": "$interval",
@@ -3050,7 +3050,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 395
+            "y": 507
           },
           "id": 87,
           "interval": "$interval",
@@ -3200,7 +3200,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 406
+            "y": 518
           },
           "id": 90,
           "interval": "$interval",
@@ -3367,7 +3367,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 414
+            "y": 526
           },
           "id": 98,
           "interval": "$interval",
@@ -3547,7 +3547,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 414
+            "y": 526
           },
           "id": 95,
           "interval": "$interval",
@@ -3818,7 +3818,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 423
+            "y": 535
           },
           "id": 52,
           "interval": "$interval",
@@ -3955,7 +3955,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3971,7 +3972,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 585
+            "y": 33
           },
           "id": 142,
           "interval": "$interval",
@@ -4064,7 +4065,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4080,7 +4082,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 593
+            "y": 41
           },
           "id": 33,
           "interval": "$interval",
@@ -4173,7 +4175,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4189,7 +4192,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 601
+            "y": 49
           },
           "id": 128,
           "interval": "$interval",
@@ -4282,7 +4285,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4298,7 +4302,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 609
+            "y": 57
           },
           "id": 129,
           "interval": "$interval",
@@ -4324,14 +4328,14 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance) (rocm_average_socket_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "expr": "sum by (instance) (rocm_average_socket_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
               "instant": false,
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "GPU Power (W)",
+          "title": "Cumulative GPU Power (W)",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -4391,7 +4395,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4407,7 +4412,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 617
+            "y": 65
           },
           "id": 130,
           "interval": "$interval",
@@ -4500,7 +4505,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4516,7 +4522,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 617
+            "y": 65
           },
           "id": 131,
           "interval": "$interval",
@@ -4639,7 +4645,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 799
+            "y": 911
           },
           "id": 143,
           "interval": "$interval",
@@ -4739,7 +4745,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 807
+            "y": 919
           },
           "id": 127,
           "interval": "$interval",
@@ -4839,7 +4845,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 815
+            "y": 927
           },
           "id": 104,
           "interval": "$interval",
@@ -4939,7 +4945,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 823
+            "y": 935
           },
           "id": 22,
           "interval": "$interval",
@@ -5039,7 +5045,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 831
+            "y": 943
           },
           "id": 25,
           "interval": "$interval",
@@ -5139,7 +5145,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 831
+            "y": 943
           },
           "id": 23,
           "interval": "$interval",
@@ -5237,8 +5243,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5254,7 +5259,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 219
+            "y": 331
           },
           "id": 144,
           "interval": "$interval",
@@ -5347,8 +5352,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5364,7 +5368,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 299
+            "y": 411
           },
           "id": 137,
           "interval": "$interval",
@@ -5457,8 +5461,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5474,7 +5477,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 307
+            "y": 419
           },
           "id": 138,
           "interval": "$interval",
@@ -5567,8 +5570,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5584,7 +5586,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 315
+            "y": 427
           },
           "id": 139,
           "interval": "$interval",
@@ -5677,8 +5679,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5694,7 +5695,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 323
+            "y": 435
           },
           "id": 140,
           "interval": "$interval",
@@ -5787,8 +5788,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5804,7 +5804,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 323
+            "y": 435
           },
           "id": 141,
           "interval": "$interval",
@@ -5928,7 +5928,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3791
+            "y": 3903
           },
           "id": 134,
           "interval": "$interval",
@@ -6052,7 +6052,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3030
+            "y": 3142
           },
           "id": 125,
           "interval": "$interval",
@@ -6180,7 +6180,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3751
+            "y": 3863
           },
           "id": 120,
           "options": {
@@ -6376,7 +6376,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3751
+            "y": 3863
           },
           "id": 121,
           "options": {
@@ -6569,8 +6569,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6586,7 +6585,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 223
+            "y": 335
           },
           "id": 43,
           "interval": "$interval",
@@ -6679,8 +6678,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6696,7 +6694,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 223
+            "y": 335
           },
           "id": 48,
           "interval": "$interval",
@@ -6803,8 +6801,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6820,7 +6817,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 224
+            "y": 336
           },
           "id": 40,
           "interval": "$interval",
@@ -6914,8 +6911,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6931,7 +6927,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 224
+            "y": 336
           },
           "id": 42,
           "interval": "$interval",
@@ -7055,7 +7051,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7758
+            "y": 7870
           },
           "id": 102,
           "interval": "$interval",
@@ -7165,7 +7161,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7758
+            "y": 7870
           },
           "id": 103,
           "interval": "$interval",
@@ -7289,7 +7285,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18532
+            "y": 18644
           },
           "id": 46,
           "interval": "$interval",
@@ -7398,7 +7394,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18532
+            "y": 18644
           },
           "id": 45,
           "interval": "$interval",
@@ -7522,7 +7518,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3036
+            "y": 3148
           },
           "id": 135,
           "interval": "$interval",
@@ -7686,7 +7682,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3085
+            "y": 3197
           },
           "id": 56,
           "interval": "$interval",
@@ -7910,7 +7906,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17086
+            "y": 17198
           },
           "id": 107,
           "interval": "$interval",
@@ -8105,7 +8101,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17086
+            "y": 17198
           },
           "id": 112,
           "interval": "$interval",
@@ -8264,7 +8260,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17094
+            "y": 17206
           },
           "id": 108,
           "interval": "$interval",
@@ -8492,7 +8488,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17094
+            "y": 17206
           },
           "id": 113,
           "interval": "$interval",
@@ -8647,7 +8643,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17102
+            "y": 17214
           },
           "id": 109,
           "interval": "$interval",
@@ -8875,7 +8871,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17102
+            "y": 17214
           },
           "id": 115,
           "interval": "$interval",
@@ -9031,7 +9027,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17110
+            "y": 17222
           },
           "id": 110,
           "interval": "$interval",
@@ -9255,7 +9251,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17110
+            "y": 17222
           },
           "id": 114,
           "interval": "$interval",

--- a/grafana/json-models/system/rms-job.json
+++ b/grafana/json-models/system/rms-job.json
@@ -1764,7 +1764,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 393
           },
           "id": 88,
           "interval": "$interval",
@@ -1874,7 +1874,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 393
           },
           "id": 89,
           "interval": "$interval",
@@ -2008,8 +2008,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2025,7 +2024,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 507
+            "y": 870
           },
           "id": 91,
           "interval": "$interval",
@@ -2109,8 +2108,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2177,7 +2175,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 515
+            "y": 878
           },
           "id": 99,
           "interval": "$interval",
@@ -2289,8 +2287,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2342,7 +2339,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 515
+            "y": 878
           },
           "id": 100,
           "interval": "$interval",
@@ -2471,8 +2468,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "#EAB839",
@@ -2492,7 +2488,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 31
+            "y": 394
           },
           "id": 28,
           "interval": "$interval",
@@ -2554,7 +2550,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 31
+            "y": 394
           },
           "id": 86,
           "interval": "$interval",
@@ -2647,8 +2643,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "#EAB839",
@@ -2668,7 +2663,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 417
+            "y": 780
           },
           "id": 29,
           "interval": "$interval",
@@ -2730,7 +2725,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 417
+            "y": 780
           },
           "id": 31,
           "interval": "$interval",
@@ -2855,8 +2850,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2872,7 +2866,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 425
+            "y": 788
           },
           "id": 24,
           "interval": "$interval",
@@ -2946,7 +2940,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 395
           },
           "id": 27,
           "interval": "$interval",
@@ -3056,7 +3050,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 395
           },
           "id": 87,
           "interval": "$interval",
@@ -3190,8 +3184,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3207,7 +3200,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 406
           },
           "id": 90,
           "interval": "$interval",
@@ -3291,8 +3284,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3375,7 +3367,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 414
           },
           "id": 98,
           "interval": "$interval",
@@ -3503,8 +3495,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3556,7 +3547,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 414
           },
           "id": 95,
           "interval": "$interval",
@@ -3703,8 +3694,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -3828,7 +3818,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 60
+            "y": 423
           },
           "id": 52,
           "interval": "$interval",
@@ -3965,8 +3955,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3982,7 +3971,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 222
+            "y": 585
           },
           "id": 142,
           "interval": "$interval",
@@ -4075,8 +4064,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4092,7 +4080,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 230
+            "y": 593
           },
           "id": 33,
           "interval": "$interval",
@@ -4185,8 +4173,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4202,7 +4189,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 238
+            "y": 601
           },
           "id": 128,
           "interval": "$interval",
@@ -4295,8 +4282,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4312,7 +4298,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 246
+            "y": 609
           },
           "id": 129,
           "interval": "$interval",
@@ -4405,8 +4391,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4422,7 +4407,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 254
+            "y": 617
           },
           "id": 130,
           "interval": "$interval",
@@ -4515,8 +4500,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4532,7 +4516,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 254
+            "y": 617
           },
           "id": 131,
           "interval": "$interval",
@@ -4639,8 +4623,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4656,7 +4639,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 436
+            "y": 799
           },
           "id": 143,
           "interval": "$interval",
@@ -4740,8 +4723,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4757,7 +4739,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 444
+            "y": 807
           },
           "id": 127,
           "interval": "$interval",
@@ -4841,8 +4823,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4858,7 +4839,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 452
+            "y": 815
           },
           "id": 104,
           "interval": "$interval",
@@ -4958,7 +4939,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 460
+            "y": 823
           },
           "id": 22,
           "interval": "$interval",
@@ -5058,7 +5039,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 468
+            "y": 831
           },
           "id": 25,
           "interval": "$interval",
@@ -5158,7 +5139,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 468
+            "y": 831
           },
           "id": 23,
           "interval": "$interval",
@@ -5273,7 +5254,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 344
+            "y": 219
           },
           "id": 144,
           "interval": "$interval",
@@ -5383,7 +5364,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 352
+            "y": 299
           },
           "id": 137,
           "interval": "$interval",
@@ -5493,7 +5474,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 360
+            "y": 307
           },
           "id": 138,
           "interval": "$interval",
@@ -5586,7 +5567,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5602,7 +5584,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 368
+            "y": 315
           },
           "id": 139,
           "interval": "$interval",
@@ -5695,7 +5677,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5711,7 +5694,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 376
+            "y": 323
           },
           "id": 140,
           "interval": "$interval",
@@ -5804,7 +5787,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5820,7 +5804,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 376
+            "y": 323
           },
           "id": 141,
           "interval": "$interval",
@@ -5944,7 +5928,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3428
+            "y": 3791
           },
           "id": 134,
           "interval": "$interval",
@@ -6068,7 +6052,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2667
+            "y": 3030
           },
           "id": 125,
           "interval": "$interval",
@@ -6196,7 +6180,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3388
+            "y": 3751
           },
           "id": 120,
           "options": {
@@ -6392,7 +6376,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3388
+            "y": 3751
           },
           "id": 121,
           "options": {
@@ -6585,7 +6569,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6601,7 +6586,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3575
+            "y": 223
           },
           "id": 43,
           "interval": "$interval",
@@ -6694,7 +6679,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6710,7 +6696,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3575
+            "y": 223
           },
           "id": 48,
           "interval": "$interval",
@@ -6817,7 +6803,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6833,7 +6820,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6247
+            "y": 224
           },
           "id": 40,
           "interval": "$interval",
@@ -6927,7 +6914,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6943,7 +6931,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6247
+            "y": 224
           },
           "id": 42,
           "interval": "$interval",
@@ -7067,7 +7055,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7395
+            "y": 7758
           },
           "id": 102,
           "interval": "$interval",
@@ -7177,7 +7165,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7395
+            "y": 7758
           },
           "id": 103,
           "interval": "$interval",
@@ -7301,7 +7289,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18169
+            "y": 18532
           },
           "id": 46,
           "interval": "$interval",
@@ -7410,7 +7398,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18169
+            "y": 18532
           },
           "id": 45,
           "interval": "$interval",
@@ -7465,7 +7453,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 132,
       "panels": [
@@ -7534,7 +7522,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2673
+            "y": 3036
           },
           "id": 135,
           "interval": "$interval",
@@ -7591,7 +7579,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 57,
       "panels": [
@@ -7698,7 +7686,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2722
+            "y": 3085
           },
           "id": 56,
           "interval": "$interval",
@@ -7791,7 +7779,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 111,
       "panels": [
@@ -7922,7 +7910,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16723
+            "y": 17086
           },
           "id": 107,
           "interval": "$interval",
@@ -8117,7 +8105,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16723
+            "y": 17086
           },
           "id": 112,
           "interval": "$interval",
@@ -8276,7 +8264,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16731
+            "y": 17094
           },
           "id": 108,
           "interval": "$interval",
@@ -8504,7 +8492,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16731
+            "y": 17094
           },
           "id": 113,
           "interval": "$interval",
@@ -8659,7 +8647,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16739
+            "y": 17102
           },
           "id": 109,
           "interval": "$interval",
@@ -8887,7 +8875,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16739
+            "y": 17102
           },
           "id": 115,
           "interval": "$interval",
@@ -9043,7 +9031,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16747
+            "y": 17110
           },
           "id": 110,
           "interval": "$interval",
@@ -9267,7 +9255,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16747
+            "y": 17110
           },
           "id": 114,
           "interval": "$interval",

--- a/grafana/json-models/system/rms-job.json
+++ b/grafana/json-models/system/rms-job.json
@@ -23,7 +23,7 @@
         "hide": false,
         "iconColor": "text",
         "name": "User Annotations",
-        "step": "5s",
+        "step": "$interval",
         "titleFormat": "{{marker}}"
       }
     ]

--- a/grafana/source/job.json
+++ b/grafana/source/job.json
@@ -2034,7 +2034,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 393
           },
           "id": 88,
           "interval": "$interval",
@@ -2144,7 +2144,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 393
           },
           "id": 89,
           "interval": "$interval",
@@ -2278,8 +2278,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2295,7 +2294,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 507
+            "y": 870
           },
           "id": 91,
           "interval": "$interval",
@@ -2379,8 +2378,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2447,7 +2445,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 515
+            "y": 878
           },
           "id": 99,
           "interval": "$interval",
@@ -2559,8 +2557,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2612,7 +2609,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 515
+            "y": 878
           },
           "id": 100,
           "interval": "$interval",
@@ -2741,8 +2738,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "#EAB839",
@@ -2762,7 +2758,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 31
+            "y": 394
           },
           "id": 28,
           "interval": "$interval",
@@ -2824,7 +2820,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 31
+            "y": 394
           },
           "id": 86,
           "interval": "$interval",
@@ -2917,8 +2913,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "#EAB839",
@@ -2938,7 +2933,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 417
+            "y": 780
           },
           "id": 29,
           "interval": "$interval",
@@ -3000,7 +2995,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 417
+            "y": 780
           },
           "id": 31,
           "interval": "$interval",
@@ -3125,8 +3120,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3142,7 +3136,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 425
+            "y": 788
           },
           "id": 24,
           "interval": "$interval",
@@ -3216,7 +3210,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 395
           },
           "id": 27,
           "interval": "$interval",
@@ -3326,7 +3320,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 395
           },
           "id": 87,
           "interval": "$interval",
@@ -3460,8 +3454,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3477,7 +3470,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 406
           },
           "id": 90,
           "interval": "$interval",
@@ -3561,8 +3554,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3645,7 +3637,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 414
           },
           "id": 98,
           "interval": "$interval",
@@ -3773,8 +3765,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3826,7 +3817,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 414
           },
           "id": 95,
           "interval": "$interval",
@@ -3973,8 +3964,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -4098,7 +4088,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 60
+            "y": 423
           },
           "id": 52,
           "interval": "$interval",
@@ -4235,8 +4225,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4252,7 +4241,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 222
+            "y": 585
           },
           "id": 142,
           "interval": "$interval",
@@ -4345,8 +4334,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4362,7 +4350,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 230
+            "y": 593
           },
           "id": 33,
           "interval": "$interval",
@@ -4455,8 +4443,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4472,7 +4459,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 238
+            "y": 601
           },
           "id": 128,
           "interval": "$interval",
@@ -4565,8 +4552,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4582,7 +4568,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 246
+            "y": 609
           },
           "id": 129,
           "interval": "$interval",
@@ -4675,8 +4661,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4692,7 +4677,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 254
+            "y": 617
           },
           "id": 130,
           "interval": "$interval",
@@ -4785,8 +4770,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4802,7 +4786,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 254
+            "y": 617
           },
           "id": 131,
           "interval": "$interval",
@@ -4909,8 +4893,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4926,7 +4909,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 436
+            "y": 799
           },
           "id": 143,
           "interval": "$interval",
@@ -5010,8 +4993,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5027,7 +5009,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 444
+            "y": 807
           },
           "id": 127,
           "interval": "$interval",
@@ -5111,8 +5093,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5128,7 +5109,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 452
+            "y": 815
           },
           "id": 104,
           "interval": "$interval",
@@ -5228,7 +5209,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 460
+            "y": 823
           },
           "id": 22,
           "interval": "$interval",
@@ -5328,7 +5309,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 468
+            "y": 831
           },
           "id": 25,
           "interval": "$interval",
@@ -5428,7 +5409,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 468
+            "y": 831
           },
           "id": 23,
           "interval": "$interval",
@@ -5543,7 +5524,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 344
+            "y": 219
           },
           "id": 144,
           "interval": "$interval",
@@ -5653,7 +5634,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 352
+            "y": 299
           },
           "id": 137,
           "interval": "$interval",
@@ -5763,7 +5744,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 360
+            "y": 307
           },
           "id": 138,
           "interval": "$interval",
@@ -5856,7 +5837,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5872,7 +5854,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 368
+            "y": 315
           },
           "id": 139,
           "interval": "$interval",
@@ -5965,7 +5947,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5981,7 +5964,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 376
+            "y": 323
           },
           "id": 140,
           "interval": "$interval",
@@ -6074,7 +6057,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6090,7 +6074,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 376
+            "y": 323
           },
           "id": 141,
           "interval": "$interval",
@@ -6214,7 +6198,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3428
+            "y": 3791
           },
           "id": 134,
           "interval": "$interval",
@@ -6338,7 +6322,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2667
+            "y": 3030
           },
           "id": 125,
           "interval": "$interval",
@@ -6466,7 +6450,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3388
+            "y": 3751
           },
           "id": 120,
           "options": {
@@ -6662,7 +6646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3388
+            "y": 3751
           },
           "id": 121,
           "options": {
@@ -6855,7 +6839,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6871,7 +6856,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3575
+            "y": 223
           },
           "id": 43,
           "interval": "$interval",
@@ -6964,7 +6949,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6980,7 +6966,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3575
+            "y": 223
           },
           "id": 48,
           "interval": "$interval",
@@ -7087,7 +7073,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -7103,7 +7090,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6247
+            "y": 224
           },
           "id": 40,
           "interval": "$interval",
@@ -7197,7 +7184,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -7213,7 +7201,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6247
+            "y": 224
           },
           "id": 42,
           "interval": "$interval",
@@ -7307,7 +7295,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -7323,7 +7312,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6255
+            "y": 280
           },
           "id": 105,
           "interval": "$interval",
@@ -7417,7 +7406,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -7433,7 +7423,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6255
+            "y": 280
           },
           "id": 106,
           "interval": "$interval",
@@ -7557,7 +7547,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7395
+            "y": 7758
           },
           "id": 102,
           "interval": "$interval",
@@ -7667,7 +7657,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7395
+            "y": 7758
           },
           "id": 103,
           "interval": "$interval",
@@ -7777,7 +7767,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7403
+            "y": 7766
           },
           "id": 116,
           "interval": "$interval",
@@ -7887,7 +7877,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7403
+            "y": 7766
           },
           "id": 117,
           "interval": "$interval",
@@ -8011,7 +8001,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18169
+            "y": 18532
           },
           "id": 46,
           "interval": "$interval",
@@ -8120,7 +8110,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18169
+            "y": 18532
           },
           "id": 45,
           "interval": "$interval",
@@ -8176,6 +8166,462 @@
         "w": 24,
         "x": 0,
         "y": 42
+      },
+      "id": 145,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 43
+          },
+          "id": 146,
+          "interval": "$interval",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (instance) (omnistat_vendor_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Vendor Host Power (W)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?",
+                "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 51
+          },
+          "id": 149,
+          "interval": "$interval",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (instance) (omnistat_vendor_accel_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Vendor GPU Power (W)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?",
+                "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 59
+          },
+          "id": 147,
+          "interval": "$interval",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (instance) (omnistat_vendor_cpu_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Vendor CPU Power (W)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?",
+                "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 67
+          },
+          "id": 148,
+          "interval": "$interval",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (instance) (omnistat_vendor_memory_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Vendor Memory Power (W)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?",
+                "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "Host Telemetry",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 132,
       "panels": [
@@ -8244,7 +8690,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2673
+            "y": 3036
           },
           "id": 135,
           "interval": "$interval",
@@ -8301,7 +8747,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 57,
       "panels": [
@@ -8408,7 +8854,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2722
+            "y": 3085
           },
           "id": 56,
           "interval": "$interval",
@@ -8501,7 +8947,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 111,
       "panels": [
@@ -8632,7 +9078,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16723
+            "y": 17086
           },
           "id": 107,
           "interval": "$interval",
@@ -8827,7 +9273,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16723
+            "y": 17086
           },
           "id": 112,
           "interval": "$interval",
@@ -8986,7 +9432,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16731
+            "y": 17094
           },
           "id": 108,
           "interval": "$interval",
@@ -9214,7 +9660,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16731
+            "y": 17094
           },
           "id": 113,
           "interval": "$interval",
@@ -9369,7 +9815,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16739
+            "y": 17102
           },
           "id": 109,
           "interval": "$interval",
@@ -9597,7 +10043,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16739
+            "y": 17102
           },
           "id": 115,
           "interval": "$interval",
@@ -9753,7 +10199,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16747
+            "y": 17110
           },
           "id": 110,
           "interval": "$interval",
@@ -9977,7 +10423,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16747
+            "y": 17110
           },
           "id": 114,
           "interval": "$interval",

--- a/grafana/source/job.json
+++ b/grafana/source/job.json
@@ -23,7 +23,7 @@
         "hide": false,
         "iconColor": "text",
         "name": "User Annotations",
-        "step": "5s",
+        "step": "$interval",
         "titleFormat": "{{marker}}"
       }
     ]

--- a/grafana/source/job.json
+++ b/grafana/source/job.json
@@ -2034,7 +2034,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 393
+            "y": 505
           },
           "id": 88,
           "interval": "$interval",
@@ -2144,7 +2144,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 393
+            "y": 505
           },
           "id": 89,
           "interval": "$interval",
@@ -2294,7 +2294,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 870
+            "y": 982
           },
           "id": 91,
           "interval": "$interval",
@@ -2445,7 +2445,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 878
+            "y": 990
           },
           "id": 99,
           "interval": "$interval",
@@ -2609,7 +2609,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 878
+            "y": 990
           },
           "id": 100,
           "interval": "$interval",
@@ -2758,7 +2758,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 394
+            "y": 506
           },
           "id": 28,
           "interval": "$interval",
@@ -2820,7 +2820,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 394
+            "y": 506
           },
           "id": 86,
           "interval": "$interval",
@@ -2933,7 +2933,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 780
+            "y": 892
           },
           "id": 29,
           "interval": "$interval",
@@ -2995,7 +2995,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 780
+            "y": 892
           },
           "id": 31,
           "interval": "$interval",
@@ -3136,7 +3136,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 788
+            "y": 900
           },
           "id": 24,
           "interval": "$interval",
@@ -3210,7 +3210,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 395
+            "y": 507
           },
           "id": 27,
           "interval": "$interval",
@@ -3320,7 +3320,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 395
+            "y": 507
           },
           "id": 87,
           "interval": "$interval",
@@ -3470,7 +3470,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 406
+            "y": 518
           },
           "id": 90,
           "interval": "$interval",
@@ -3637,7 +3637,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 414
+            "y": 526
           },
           "id": 98,
           "interval": "$interval",
@@ -3817,7 +3817,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 414
+            "y": 526
           },
           "id": 95,
           "interval": "$interval",
@@ -4088,7 +4088,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 423
+            "y": 535
           },
           "id": 52,
           "interval": "$interval",
@@ -4225,7 +4225,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4241,7 +4242,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 585
+            "y": 33
           },
           "id": 142,
           "interval": "$interval",
@@ -4334,7 +4335,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4350,7 +4352,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 593
+            "y": 41
           },
           "id": 33,
           "interval": "$interval",
@@ -4443,7 +4445,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4459,7 +4462,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 601
+            "y": 49
           },
           "id": 128,
           "interval": "$interval",
@@ -4552,7 +4555,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4568,7 +4572,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 609
+            "y": 57
           },
           "id": 129,
           "interval": "$interval",
@@ -4594,14 +4598,14 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance) (rocm_average_socket_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "expr": "sum by (instance) (rocm_average_socket_power_watts * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
               "instant": false,
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "GPU Power (W)",
+          "title": "Cumulative GPU Power (W)",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -4661,7 +4665,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4677,7 +4682,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 617
+            "y": 65
           },
           "id": 130,
           "interval": "$interval",
@@ -4770,7 +4775,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4786,7 +4792,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 617
+            "y": 65
           },
           "id": 131,
           "interval": "$interval",
@@ -4909,7 +4915,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 799
+            "y": 911
           },
           "id": 143,
           "interval": "$interval",
@@ -5009,7 +5015,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 807
+            "y": 919
           },
           "id": 127,
           "interval": "$interval",
@@ -5109,7 +5115,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 815
+            "y": 927
           },
           "id": 104,
           "interval": "$interval",
@@ -5209,7 +5215,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 823
+            "y": 935
           },
           "id": 22,
           "interval": "$interval",
@@ -5309,7 +5315,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 831
+            "y": 943
           },
           "id": 25,
           "interval": "$interval",
@@ -5409,7 +5415,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 831
+            "y": 943
           },
           "id": 23,
           "interval": "$interval",
@@ -5507,8 +5513,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5524,7 +5529,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 219
+            "y": 331
           },
           "id": 144,
           "interval": "$interval",
@@ -5617,8 +5622,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5634,7 +5638,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 299
+            "y": 411
           },
           "id": 137,
           "interval": "$interval",
@@ -5727,8 +5731,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5744,7 +5747,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 307
+            "y": 419
           },
           "id": 138,
           "interval": "$interval",
@@ -5837,8 +5840,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5854,7 +5856,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 315
+            "y": 427
           },
           "id": 139,
           "interval": "$interval",
@@ -5947,8 +5949,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5964,7 +5965,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 323
+            "y": 435
           },
           "id": 140,
           "interval": "$interval",
@@ -6057,8 +6058,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6074,7 +6074,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 323
+            "y": 435
           },
           "id": 141,
           "interval": "$interval",
@@ -6198,7 +6198,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3791
+            "y": 3903
           },
           "id": 134,
           "interval": "$interval",
@@ -6322,7 +6322,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3030
+            "y": 3142
           },
           "id": 125,
           "interval": "$interval",
@@ -6450,7 +6450,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3751
+            "y": 3863
           },
           "id": 120,
           "options": {
@@ -6646,7 +6646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3751
+            "y": 3863
           },
           "id": 121,
           "options": {
@@ -6839,8 +6839,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6856,7 +6855,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 223
+            "y": 335
           },
           "id": 43,
           "interval": "$interval",
@@ -6949,8 +6948,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6966,7 +6964,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 223
+            "y": 335
           },
           "id": 48,
           "interval": "$interval",
@@ -7073,8 +7071,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7090,7 +7087,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 224
+            "y": 336
           },
           "id": 40,
           "interval": "$interval",
@@ -7184,8 +7181,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7201,7 +7197,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 224
+            "y": 336
           },
           "id": 42,
           "interval": "$interval",
@@ -7295,8 +7291,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7312,7 +7307,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 280
+            "y": 392
           },
           "id": 105,
           "interval": "$interval",
@@ -7406,8 +7401,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7423,7 +7417,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 280
+            "y": 392
           },
           "id": 106,
           "interval": "$interval",
@@ -7547,7 +7541,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7758
+            "y": 7870
           },
           "id": 102,
           "interval": "$interval",
@@ -7657,7 +7651,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7758
+            "y": 7870
           },
           "id": 103,
           "interval": "$interval",
@@ -7767,7 +7761,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7766
+            "y": 7878
           },
           "id": 116,
           "interval": "$interval",
@@ -7877,7 +7871,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7766
+            "y": 7878
           },
           "id": 117,
           "interval": "$interval",
@@ -8001,7 +7995,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18532
+            "y": 18644
           },
           "id": 46,
           "interval": "$interval",
@@ -8110,7 +8104,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18532
+            "y": 18644
           },
           "id": 45,
           "interval": "$interval",
@@ -8235,7 +8229,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 123
           },
           "id": 146,
           "interval": "$interval",
@@ -8329,8 +8323,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8346,7 +8339,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 51
+            "y": 131
           },
           "id": 149,
           "interval": "$interval",
@@ -8439,8 +8432,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8456,7 +8448,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 59
+            "y": 139
           },
           "id": 147,
           "interval": "$interval",
@@ -8549,8 +8541,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8566,7 +8557,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 67
+            "y": 147
           },
           "id": 148,
           "interval": "$interval",
@@ -8690,7 +8681,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3036
+            "y": 3148
           },
           "id": 135,
           "interval": "$interval",
@@ -8854,7 +8845,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3085
+            "y": 3197
           },
           "id": 56,
           "interval": "$interval",
@@ -9078,7 +9069,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17086
+            "y": 17198
           },
           "id": 107,
           "interval": "$interval",
@@ -9273,7 +9264,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17086
+            "y": 17198
           },
           "id": 112,
           "interval": "$interval",
@@ -9432,7 +9423,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17094
+            "y": 17206
           },
           "id": 108,
           "interval": "$interval",
@@ -9660,7 +9651,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17094
+            "y": 17206
           },
           "id": 113,
           "interval": "$interval",
@@ -9815,7 +9806,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17102
+            "y": 17214
           },
           "id": 109,
           "interval": "$interval",
@@ -10043,7 +10034,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17102
+            "y": 17214
           },
           "id": 115,
           "interval": "$interval",
@@ -10199,7 +10190,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17110
+            "y": 17222
           },
           "id": 110,
           "interval": "$interval",
@@ -10423,7 +10414,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17110
+            "y": 17222
           },
           "id": 114,
           "interval": "$interval",


### PR DESCRIPTION
Changes:
- [x] Use `$interval` as step when querying annotations, instead of the hardcoded 5s step.
- [x] Switch GPU Power aggregated by node to display cumulative power instead of averaged power. This approach ensures we are not displaying wrong averages with MI250, which reports 0 for one of the GCDs and skews the averages.
- [x] Add host-level power panels from vendor metrics. Disabled by default in all dashboards.