### PR TITLE
Track decoder utilization

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -139,8 +139,7 @@ maximum number of wavefronts that a CU can handle simultaneously.
 The VCN (Video Core Next) collection mechanism is an optional capability of
 the AMD SMI data collector that provides metrics for monitoring video decoding
 operations on AMD GPUs. GPUs may contain multiple VCN engines to handle
-parallel video decoding workloads, which can be identified with the `engine`
-label.
+parallel video decoding workloads.
 
 ```{note}
 The VCN collector requires enabling the AMD SMI collector (`enable_amd_smi`).
@@ -149,9 +148,9 @@ It is **not** supported by the ROCm SMI collector (`enable_rocm_smi`).
 
 **Collectors**: `enable_amd_smi`, `enable_vcn`
 
-| GPU Metric                            | Description                          |
-| :------------------------------------ | :----------------------------------- |
-| `rocm_decoder_utilization_percentage` | Video decoder engine utilization (%). Labels: `engine`. |
+| GPU Metric                                    | Description                          |
+| :-------------------------------------------- | :----------------------------------- |
+| `rocm_average_decoder_utilization_percentage` | Decoder utilization averaged across all engines in the GPU (%). |
 
 
 ## Network

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -136,13 +136,18 @@ maximum number of wavefronts that a CU can handle simultaneously.
 
 ## VCN
 
-The VCN (Video Core Next) collection mechanism is another optional capability
-of the ROCm data collectors that provides metrics for monitoring video
-decoding operations on AMD GPUs. GPUs may contain multiple VCN engines to
-handle parallel video decoding workloads, which can be identified with the
-`engine` label.
+The VCN (Video Core Next) collection mechanism is an optional capability of
+the AMD SMI data collector that provides metrics for monitoring video decoding
+operations on AMD GPUs. GPUs may contain multiple VCN engines to handle
+parallel video decoding workloads, which can be identified with the `engine`
+label.
 
-**Collectors**: `enable_rocm_smi` or `enable_amd_smi`, `enable_vcn`
+```{note}
+The VCN collector requires enabling the AMD SMI collector (`enable_amd_smi`).
+It is **not** supported by the ROCm SMI collector (`enable_rocm_smi`).
+```
+
+**Collectors**: `enable_amd_smi`, `enable_vcn`
 
 | GPU Metric                            | Description                          |
 | :------------------------------------ | :----------------------------------- |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -134,6 +134,21 @@ maximum number of wavefronts that a CU can handle simultaneously.
 | `rocm_compute_unit_occupancy` | Number of used compute units. |
 
 
+## VCN
+
+The VCN (Video Core Next) collection mechanism is another optional capability
+of the ROCm data collectors that provides metrics for monitoring video
+decoding operations on AMD GPUs. GPUs may contain multiple VCN engines to
+handle parallel video decoding workloads, which can be identified with the
+`engine` label.
+
+**Collectors**: `enable_rocm_smi` or `enable_amd_smi`, `enable_vcn`
+
+| GPU Metric                            | Description                          |
+| :------------------------------------ | :----------------------------------- |
+| `rocm_decoder_utilization_percentage` | Video decoder engine utilization (%). Labels: `engine`. |
+
+
 ## Network
 
 The network data collector enables metrics providing information about data

--- a/grafana/json-models/system/rms-global.json
+++ b/grafana/json-models/system/rms-global.json
@@ -1020,7 +1020,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1380
+            "y": 3190
           },
           "id": 110,
           "options": {
@@ -1139,7 +1139,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1380
+            "y": 3190
           },
           "id": 112,
           "options": {
@@ -1263,7 +1263,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2048
+            "y": 3858
           },
           "id": 113,
           "options": {
@@ -1390,7 +1390,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2048
+            "y": 3858
           },
           "id": 140,
           "options": {
@@ -1537,7 +1537,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2054
+            "y": 3864
           },
           "id": 139,
           "options": {
@@ -1768,7 +1768,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 639
           },
           "id": 99,
           "interval": "5s",
@@ -2038,7 +2038,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 3325
+            "y": 5135
           },
           "id": 12,
           "options": {
@@ -2208,7 +2208,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 3325
+            "y": 5135
           },
           "id": 20,
           "options": {
@@ -2375,7 +2375,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 3753
+            "y": 5563
           },
           "id": 21,
           "options": {
@@ -2580,7 +2580,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 3753
+            "y": 5563
           },
           "id": 22,
           "options": {
@@ -2800,7 +2800,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 14214
+            "y": 16024
           },
           "id": 28,
           "options": {
@@ -3071,7 +3071,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -3083,7 +3084,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 4232
+            "y": 324
           },
           "id": 23,
           "options": {
@@ -3096,11 +3097,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3203,7 +3205,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3218,7 +3221,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 545
+            "y": 325
           },
           "id": 26,
           "options": {
@@ -3303,7 +3306,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1202
+            "y": 370
           },
           "id": 6,
           "options": {
@@ -3425,7 +3428,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -3437,7 +3441,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1211
+            "y": 379
           },
           "id": 29,
           "options": {
@@ -3450,12 +3454,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3533,7 +3538,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -3545,7 +3551,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1211
+            "y": 379
           },
           "id": 103,
           "options": {
@@ -3558,12 +3564,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3675,7 +3682,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1386
+            "y": 3196
           },
           "id": 102,
           "options": {
@@ -3791,7 +3798,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1395
+            "y": 3205
           },
           "id": 38,
           "options": {
@@ -3907,7 +3914,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1395
+            "y": 3205
           },
           "id": 39,
           "options": {
@@ -4023,7 +4030,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1404
+            "y": 3214
           },
           "id": 109,
           "options": {
@@ -4145,7 +4152,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 547
+            "y": 2357
           },
           "id": 106,
           "options": {
@@ -4254,7 +4261,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 841
+            "y": 2651
           },
           "id": 119,
           "options": {
@@ -4363,7 +4370,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 850
+            "y": 2660
           },
           "id": 104,
           "options": {
@@ -4471,7 +4478,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 850
+            "y": 2660
           },
           "id": 105,
           "options": {
@@ -4593,7 +4600,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 548
+            "y": 2358
           },
           "id": 124,
           "options": {
@@ -4702,7 +4709,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 824
+            "y": 2634
           },
           "id": 125,
           "options": {
@@ -4827,7 +4834,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 289
+            "y": 2099
           },
           "id": 142,
           "options": {
@@ -5023,7 +5030,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 289
+            "y": 2099
           },
           "id": 143,
           "options": {
@@ -5217,7 +5224,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 481
+            "y": 2291
           },
           "id": 144,
           "options": {
@@ -5323,7 +5330,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 481
+            "y": 2291
           },
           "id": 145,
           "options": {
@@ -5420,7 +5427,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 489
+            "y": 2299
           },
           "id": 146,
           "options": {
@@ -5570,7 +5577,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 489
+            "y": 2299
           },
           "id": 147,
           "options": {
@@ -5677,6 +5684,231 @@
         "x": 0,
         "y": 24
       },
+      "id": 156,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 331
+          },
+          "id": 157,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg(rocm_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "Decoder",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregate Cluster GPU Decoder Utilization (%)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 340
+          },
+          "id": 159,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Name",
+              "sortDesc": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (instance) (rocm_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Decoder Utlization (%)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "(.*):(.*)",
+                "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "GPU - Video",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
       "id": 36,
       "panels": [
         {
@@ -5743,7 +5975,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3333
+            "y": 5143
           },
           "id": 35,
           "options": {
@@ -5850,7 +6082,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3397
+            "y": 5207
           },
           "id": 65,
           "options": {
@@ -5957,7 +6189,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3397
+            "y": 5207
           },
           "id": 66,
           "options": {
@@ -6010,7 +6242,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 117,
       "panels": [
@@ -6065,8 +6297,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6082,7 +6313,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 26
+            "y": 1836
           },
           "id": 118,
           "options": {
@@ -6190,7 +6421,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 194
+            "y": 2004
           },
           "id": 134,
           "options": {
@@ -6243,7 +6474,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 27
       },
       "id": 120,
       "panels": [
@@ -6312,7 +6543,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3647
+            "y": 5457
           },
           "id": 92,
           "options": {
@@ -6425,7 +6656,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3655
+            "y": 5465
           },
           "id": 135,
           "options": {
@@ -6534,7 +6765,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3655
+            "y": 5465
           },
           "id": 136,
           "options": {
@@ -6588,7 +6819,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 28
       },
       "id": 116,
       "panels": [
@@ -6641,8 +6872,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6658,7 +6888,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 28
+            "y": 1838
           },
           "id": 121,
           "options": {
@@ -6764,8 +6994,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6781,7 +7010,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 1846
           },
           "id": 137,
           "options": {
@@ -6874,8 +7103,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6891,7 +7119,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 1846
           },
           "id": 138,
           "options": {
@@ -6945,7 +7173,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 29
       },
       "id": 67,
       "panels": [
@@ -6998,8 +7226,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7015,7 +7242,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 29
+            "y": 1839
           },
           "id": 115,
           "options": {
@@ -7121,8 +7348,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7138,7 +7364,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 1847
           },
           "id": 96,
           "options": {
@@ -7231,8 +7457,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7248,7 +7473,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 1847
           },
           "id": 94,
           "options": {
@@ -7341,8 +7566,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7358,7 +7582,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 1855
           },
           "id": 93,
           "options": {
@@ -7451,8 +7675,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7468,7 +7691,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 1855
           },
           "id": 95,
           "options": {

--- a/grafana/json-models/system/rms-global.json
+++ b/grafana/json-models/system/rms-global.json
@@ -1020,7 +1020,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3190
+            "y": 5284
           },
           "id": 110,
           "options": {
@@ -1139,7 +1139,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 3190
+            "y": 5284
           },
           "id": 112,
           "options": {
@@ -1263,7 +1263,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3858
+            "y": 5952
           },
           "id": 113,
           "options": {
@@ -1390,7 +1390,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 3858
+            "y": 5952
           },
           "id": 140,
           "options": {
@@ -1537,7 +1537,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3864
+            "y": 5958
           },
           "id": 139,
           "options": {
@@ -1768,7 +1768,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 639
+            "y": 2733
           },
           "id": 99,
           "interval": "5s",
@@ -2038,7 +2038,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 5135
+            "y": 7229
           },
           "id": 12,
           "options": {
@@ -2208,7 +2208,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 5135
+            "y": 7229
           },
           "id": 20,
           "options": {
@@ -2375,7 +2375,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 5563
+            "y": 7657
           },
           "id": 21,
           "options": {
@@ -2580,7 +2580,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 5563
+            "y": 7657
           },
           "id": 22,
           "options": {
@@ -2800,7 +2800,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 16024
+            "y": 18118
           },
           "id": 28,
           "options": {
@@ -3071,8 +3071,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -3084,7 +3083,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 324
+            "y": 2418
           },
           "id": 23,
           "options": {
@@ -3221,7 +3220,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 325
+            "y": 19
           },
           "id": 26,
           "options": {
@@ -3306,7 +3305,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 370
+            "y": 949
           },
           "id": 6,
           "options": {
@@ -3365,7 +3364,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Utilization by Node",
+          "title": "GPU Utilization per Node",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -3441,7 +3440,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 379
+            "y": 958
           },
           "id": 29,
           "options": {
@@ -3475,7 +3474,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Utlization (%) in Allocated Nodes",
+          "title": "GPU Utilization (%) in Allocated Nodes",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -3551,7 +3550,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 379
+            "y": 958
           },
           "id": 103,
           "options": {
@@ -3585,7 +3584,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Utlization (%) in Unallocated Nodes",
+          "title": "GPU Utilization (%) in Unallocated Nodes",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -3662,7 +3661,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -3682,7 +3682,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3196
+            "y": 20
           },
           "id": 102,
           "options": {
@@ -3695,12 +3695,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3778,7 +3779,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -3798,7 +3800,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3205
+            "y": 326
           },
           "id": 38,
           "options": {
@@ -3811,12 +3813,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3894,7 +3897,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -3914,7 +3918,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3205
+            "y": 326
           },
           "id": 39,
           "options": {
@@ -3927,12 +3931,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -4010,7 +4015,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -4030,7 +4036,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3214
+            "y": 335
           },
           "id": 109,
           "options": {
@@ -4043,12 +4049,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -4140,7 +4147,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4152,7 +4160,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2357
+            "y": 21
           },
           "id": 106,
           "options": {
@@ -4249,7 +4257,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4261,7 +4270,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2651
+            "y": 300
           },
           "id": 119,
           "options": {
@@ -4295,7 +4304,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Power per Node",
+          "title": "GPU Power per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -4358,7 +4367,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4370,7 +4380,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 2660
+            "y": 309
           },
           "id": 104,
           "options": {
@@ -4383,12 +4393,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -4466,7 +4477,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4478,7 +4490,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 2660
+            "y": 309
           },
           "id": 105,
           "options": {
@@ -4491,12 +4503,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -4588,7 +4601,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4600,7 +4614,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2358
+            "y": 22
           },
           "id": 124,
           "options": {
@@ -4634,7 +4648,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Clock Frequency per Node",
+          "title": "GPU Clock Frequency per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -4697,7 +4711,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4709,7 +4724,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2634
+            "y": 283
           },
           "id": 125,
           "options": {
@@ -4743,7 +4758,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Memory Clock Frequency per Node",
+          "title": "GPU Memory Clock Frequency per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -4819,7 +4834,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4834,7 +4850,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2099
+            "y": 24
           },
           "id": 142,
           "options": {
@@ -5015,7 +5031,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5030,7 +5047,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2099
+            "y": 24
           },
           "id": 143,
           "options": {
@@ -5209,7 +5226,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5224,7 +5242,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2291
+            "y": 59
           },
           "id": 144,
           "options": {
@@ -5315,7 +5333,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5330,7 +5349,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2291
+            "y": 59
           },
           "id": 145,
           "options": {
@@ -5412,7 +5431,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5427,7 +5447,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2299
+            "y": 67
           },
           "id": 146,
           "options": {
@@ -5562,7 +5582,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5577,7 +5598,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2299
+            "y": 67
           },
           "id": 147,
           "options": {
@@ -5752,7 +5773,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 331
+            "y": 25
           },
           "id": 157,
           "options": {
@@ -5777,7 +5798,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg(rocm_decoder_utilization_percentage)",
+              "expr": "avg(rocm_average_decoder_utilization_percentage)",
               "instant": false,
               "legendFormat": "Decoder",
               "range": true,
@@ -5851,7 +5872,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 340
+            "y": 34
           },
           "id": 159,
           "options": {
@@ -5878,20 +5899,130 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance) (rocm_decoder_utilization_percentage)",
+              "expr": "avg by (instance) (rocm_average_decoder_utilization_percentage)",
               "instant": false,
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "GPU Decoder Utlization (%)",
+          "title": "GPU Decoder Utilization (%) per Node",
           "transformations": [
             {
               "id": "renameByRegex",
               "options": {
                 "regex": "(.*):(.*)",
                 "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 43
+          },
+          "id": 160,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Name",
+              "sortDesc": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (instance,card) (rocm_average_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "{{instance}}, {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Decoder Utilization (%) per GPU",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?, (.+)",
+                "renamePattern": "Node/ID: $1/$2"
               }
             }
           ],
@@ -5960,7 +6091,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5975,7 +6107,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5143
+            "y": 1976
           },
           "id": 35,
           "options": {
@@ -5986,12 +6118,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -6082,7 +6215,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5207
+            "y": 1984
           },
           "id": 65,
           "options": {
@@ -6189,7 +6322,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5207
+            "y": 1984
           },
           "id": 66,
           "options": {
@@ -6313,7 +6446,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1836
+            "y": 3930
           },
           "id": 118,
           "options": {
@@ -6421,7 +6554,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2004
+            "y": 4098
           },
           "id": 134,
           "options": {
@@ -6543,7 +6676,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5457
+            "y": 7551
           },
           "id": 92,
           "options": {
@@ -6656,7 +6789,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5465
+            "y": 7559
           },
           "id": 135,
           "options": {
@@ -6765,7 +6898,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5465
+            "y": 7559
           },
           "id": 136,
           "options": {
@@ -6888,7 +7021,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1838
+            "y": 3932
           },
           "id": 121,
           "options": {
@@ -7010,7 +7143,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1846
+            "y": 3940
           },
           "id": 137,
           "options": {
@@ -7119,7 +7252,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1846
+            "y": 3940
           },
           "id": 138,
           "options": {
@@ -7242,7 +7375,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1839
+            "y": 3933
           },
           "id": 115,
           "options": {
@@ -7364,7 +7497,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1847
+            "y": 3941
           },
           "id": 96,
           "options": {
@@ -7473,7 +7606,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1847
+            "y": 3941
           },
           "id": 94,
           "options": {
@@ -7582,7 +7715,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1855
+            "y": 3949
           },
           "id": 93,
           "options": {
@@ -7691,7 +7824,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1855
+            "y": 3949
           },
           "id": 95,
           "options": {

--- a/grafana/json-models/system/standalone-global.json
+++ b/grafana/json-models/system/standalone-global.json
@@ -722,7 +722,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1380
+            "y": 3190
           },
           "id": 110,
           "options": {
@@ -841,7 +841,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1380
+            "y": 3190
           },
           "id": 112,
           "options": {
@@ -965,7 +965,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2048
+            "y": 3858
           },
           "id": 113,
           "options": {
@@ -1092,7 +1092,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2048
+            "y": 3858
           },
           "id": 140,
           "options": {
@@ -1239,7 +1239,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2054
+            "y": 3864
           },
           "id": 139,
           "options": {
@@ -1378,7 +1378,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1393,7 +1394,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 545
+            "y": 325
           },
           "id": 26,
           "options": {
@@ -1478,7 +1479,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1202
+            "y": 370
           },
           "id": 6,
           "options": {
@@ -1634,7 +1635,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1386
+            "y": 3196
           },
           "id": 102,
           "options": {
@@ -1750,7 +1751,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1404
+            "y": 3214
           },
           "id": 109,
           "options": {
@@ -1872,7 +1873,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 547
+            "y": 2357
           },
           "id": 106,
           "options": {
@@ -1981,7 +1982,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 841
+            "y": 2651
           },
           "id": 119,
           "options": {
@@ -2104,7 +2105,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 548
+            "y": 2358
           },
           "id": 124,
           "options": {
@@ -2213,7 +2214,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 824
+            "y": 2634
           },
           "id": 125,
           "options": {
@@ -2338,7 +2339,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 289
+            "y": 2099
           },
           "id": 142,
           "options": {
@@ -2534,7 +2535,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 289
+            "y": 2099
           },
           "id": 143,
           "options": {
@@ -2728,7 +2729,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 481
+            "y": 2291
           },
           "id": 144,
           "options": {
@@ -2834,7 +2835,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 481
+            "y": 2291
           },
           "id": 145,
           "options": {
@@ -2931,7 +2932,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 489
+            "y": 2299
           },
           "id": 146,
           "options": {
@@ -3081,7 +3082,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 489
+            "y": 2299
           },
           "id": 147,
           "options": {
@@ -3188,6 +3189,231 @@
         "x": 0,
         "y": 24
       },
+      "id": 156,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 331
+          },
+          "id": 157,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg(rocm_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "Decoder",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregate Cluster GPU Decoder Utilization (%)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 340
+          },
+          "id": 159,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Name",
+              "sortDesc": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (instance) (rocm_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Decoder Utlization (%)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "(.*):(.*)",
+                "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "GPU - Video",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
       "id": 36,
       "panels": [
         {
@@ -3254,7 +3480,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3333
+            "y": 5143
           },
           "id": 35,
           "options": {
@@ -3307,7 +3533,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 117,
       "panels": [
@@ -3362,8 +3588,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3379,7 +3604,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 26
+            "y": 1836
           },
           "id": 118,
           "options": {
@@ -3487,7 +3712,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 194
+            "y": 2004
           },
           "id": 134,
           "options": {
@@ -3540,7 +3765,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 27
       },
       "id": 120,
       "panels": [
@@ -3609,7 +3834,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3647
+            "y": 5457
           },
           "id": 92,
           "options": {
@@ -3722,7 +3947,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3655
+            "y": 5465
           },
           "id": 135,
           "options": {
@@ -3831,7 +4056,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3655
+            "y": 5465
           },
           "id": 136,
           "options": {
@@ -3885,7 +4110,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 28
       },
       "id": 116,
       "panels": [
@@ -3938,8 +4163,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3955,7 +4179,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 28
+            "y": 1838
           },
           "id": 121,
           "options": {
@@ -4061,8 +4285,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4078,7 +4301,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 1846
           },
           "id": 137,
           "options": {
@@ -4171,8 +4394,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4188,7 +4410,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 1846
           },
           "id": 138,
           "options": {
@@ -4242,7 +4464,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 29
       },
       "id": 67,
       "panels": [
@@ -4295,8 +4517,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4312,7 +4533,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 29
+            "y": 1839
           },
           "id": 115,
           "options": {

--- a/grafana/json-models/system/standalone-global.json
+++ b/grafana/json-models/system/standalone-global.json
@@ -722,7 +722,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3190
+            "y": 5284
           },
           "id": 110,
           "options": {
@@ -841,7 +841,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 3190
+            "y": 5284
           },
           "id": 112,
           "options": {
@@ -965,7 +965,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3858
+            "y": 5952
           },
           "id": 113,
           "options": {
@@ -1092,7 +1092,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 3858
+            "y": 5952
           },
           "id": 140,
           "options": {
@@ -1239,7 +1239,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3864
+            "y": 5958
           },
           "id": 139,
           "options": {
@@ -1394,7 +1394,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 325
+            "y": 19
           },
           "id": 26,
           "options": {
@@ -1479,7 +1479,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 370
+            "y": 949
           },
           "id": 6,
           "options": {
@@ -1538,7 +1538,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Utilization by Node",
+          "title": "GPU Utilization per Node",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -1615,7 +1615,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -1635,7 +1636,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3196
+            "y": 20
           },
           "id": 102,
           "options": {
@@ -1648,12 +1649,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -1731,7 +1733,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -1751,7 +1754,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3214
+            "y": 335
           },
           "id": 109,
           "options": {
@@ -1764,12 +1767,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -1861,7 +1865,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -1873,7 +1878,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2357
+            "y": 21
           },
           "id": 106,
           "options": {
@@ -1970,7 +1975,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -1982,7 +1988,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2651
+            "y": 300
           },
           "id": 119,
           "options": {
@@ -2016,7 +2022,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Power per Node",
+          "title": "GPU Power per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -2093,7 +2099,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -2105,7 +2112,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2358
+            "y": 22
           },
           "id": 124,
           "options": {
@@ -2139,7 +2146,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Clock Frequency per Node",
+          "title": "GPU Clock Frequency per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -2202,7 +2209,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -2214,7 +2222,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2634
+            "y": 283
           },
           "id": 125,
           "options": {
@@ -2248,7 +2256,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Memory Clock Frequency per Node",
+          "title": "GPU Memory Clock Frequency per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -2324,7 +2332,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2339,7 +2348,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2099
+            "y": 24
           },
           "id": 142,
           "options": {
@@ -2520,7 +2529,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2535,7 +2545,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2099
+            "y": 24
           },
           "id": 143,
           "options": {
@@ -2714,7 +2724,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2729,7 +2740,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2291
+            "y": 59
           },
           "id": 144,
           "options": {
@@ -2820,7 +2831,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2835,7 +2847,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2291
+            "y": 59
           },
           "id": 145,
           "options": {
@@ -2917,7 +2929,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2932,7 +2945,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2299
+            "y": 67
           },
           "id": 146,
           "options": {
@@ -3067,7 +3080,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3082,7 +3096,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2299
+            "y": 67
           },
           "id": 147,
           "options": {
@@ -3257,7 +3271,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 331
+            "y": 25
           },
           "id": 157,
           "options": {
@@ -3282,7 +3296,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg(rocm_decoder_utilization_percentage)",
+              "expr": "avg(rocm_average_decoder_utilization_percentage)",
               "instant": false,
               "legendFormat": "Decoder",
               "range": true,
@@ -3356,7 +3370,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 340
+            "y": 34
           },
           "id": 159,
           "options": {
@@ -3383,20 +3397,130 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance) (rocm_decoder_utilization_percentage)",
+              "expr": "avg by (instance) (rocm_average_decoder_utilization_percentage)",
               "instant": false,
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "GPU Decoder Utlization (%)",
+          "title": "GPU Decoder Utilization (%) per Node",
           "transformations": [
             {
               "id": "renameByRegex",
               "options": {
                 "regex": "(.*):(.*)",
                 "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 43
+          },
+          "id": 160,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Name",
+              "sortDesc": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (instance,card) (rocm_average_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "{{instance}}, {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Decoder Utilization (%) per GPU",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?, (.+)",
+                "renamePattern": "Node/ID: $1/$2"
               }
             }
           ],
@@ -3465,7 +3589,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3480,7 +3605,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5143
+            "y": 1976
           },
           "id": 35,
           "options": {
@@ -3491,12 +3616,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3604,7 +3730,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1836
+            "y": 3930
           },
           "id": 118,
           "options": {
@@ -3712,7 +3838,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2004
+            "y": 4098
           },
           "id": 134,
           "options": {
@@ -3834,7 +3960,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5457
+            "y": 7551
           },
           "id": 92,
           "options": {
@@ -3947,7 +4073,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5465
+            "y": 7559
           },
           "id": 135,
           "options": {
@@ -4056,7 +4182,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5465
+            "y": 7559
           },
           "id": 136,
           "options": {
@@ -4179,7 +4305,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1838
+            "y": 3932
           },
           "id": 121,
           "options": {
@@ -4301,7 +4427,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1846
+            "y": 3940
           },
           "id": 137,
           "options": {
@@ -4410,7 +4536,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1846
+            "y": 3940
           },
           "id": 138,
           "options": {
@@ -4533,7 +4659,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1839
+            "y": 3933
           },
           "id": 115,
           "options": {

--- a/grafana/source/global.json
+++ b/grafana/source/global.json
@@ -1020,7 +1020,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3190
+            "y": 5284
           },
           "id": 110,
           "options": {
@@ -1139,7 +1139,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 3190
+            "y": 5284
           },
           "id": 112,
           "options": {
@@ -1263,7 +1263,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3858
+            "y": 5952
           },
           "id": 113,
           "options": {
@@ -1390,7 +1390,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 3858
+            "y": 5952
           },
           "id": 140,
           "options": {
@@ -1537,7 +1537,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3864
+            "y": 5958
           },
           "id": 139,
           "options": {
@@ -1768,7 +1768,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 639
+            "y": 2733
           },
           "id": 99,
           "interval": "5s",
@@ -2038,7 +2038,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 5135
+            "y": 7229
           },
           "id": 12,
           "options": {
@@ -2208,7 +2208,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 5135
+            "y": 7229
           },
           "id": 20,
           "options": {
@@ -2375,7 +2375,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 5563
+            "y": 7657
           },
           "id": 21,
           "options": {
@@ -2580,7 +2580,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 5563
+            "y": 7657
           },
           "id": 22,
           "options": {
@@ -2800,7 +2800,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 16024
+            "y": 18118
           },
           "id": 28,
           "options": {
@@ -3071,8 +3071,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -3084,7 +3083,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 324
+            "y": 2418
           },
           "id": 23,
           "options": {
@@ -3221,7 +3220,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 325
+            "y": 19
           },
           "id": 26,
           "options": {
@@ -3306,7 +3305,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 370
+            "y": 949
           },
           "id": 6,
           "options": {
@@ -3365,7 +3364,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Utilization by Node",
+          "title": "GPU Utilization per Node",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -3441,7 +3440,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 379
+            "y": 958
           },
           "id": 29,
           "options": {
@@ -3475,7 +3474,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Utlization (%) in Allocated Nodes",
+          "title": "GPU Utilization (%) in Allocated Nodes",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -3551,7 +3550,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 379
+            "y": 958
           },
           "id": 103,
           "options": {
@@ -3585,7 +3584,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Utlization (%) in Unallocated Nodes",
+          "title": "GPU Utilization (%) in Unallocated Nodes",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -3662,7 +3661,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -3682,7 +3682,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3196
+            "y": 20
           },
           "id": 102,
           "options": {
@@ -3695,12 +3695,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3778,7 +3779,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -3798,7 +3800,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3205
+            "y": 326
           },
           "id": 38,
           "options": {
@@ -3811,12 +3813,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3894,7 +3897,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -3914,7 +3918,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3205
+            "y": 326
           },
           "id": 39,
           "options": {
@@ -3927,12 +3931,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -4010,7 +4015,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -4030,7 +4036,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3214
+            "y": 335
           },
           "id": 109,
           "options": {
@@ -4043,12 +4049,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -4140,7 +4147,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4152,7 +4160,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2357
+            "y": 21
           },
           "id": 106,
           "options": {
@@ -4249,7 +4257,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4261,7 +4270,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2651
+            "y": 300
           },
           "id": 119,
           "options": {
@@ -4295,7 +4304,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Power per Node",
+          "title": "GPU Power per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -4358,7 +4367,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4370,7 +4380,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 2660
+            "y": 309
           },
           "id": 104,
           "options": {
@@ -4383,12 +4393,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -4466,7 +4477,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4478,7 +4490,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 2660
+            "y": 309
           },
           "id": 105,
           "options": {
@@ -4491,12 +4503,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -4588,7 +4601,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4600,7 +4614,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2358
+            "y": 22
           },
           "id": 124,
           "options": {
@@ -4634,7 +4648,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Clock Frequency per Node",
+          "title": "GPU Clock Frequency per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -4697,7 +4711,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -4709,7 +4724,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2634
+            "y": 283
           },
           "id": 125,
           "options": {
@@ -4743,7 +4758,7 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Memory Clock Frequency per Node",
+          "title": "GPU Memory Clock Frequency per GPU",
           "transformations": [
             {
               "id": "renameByRegex",
@@ -4835,7 +4850,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 916
+            "y": 23
           },
           "id": 123,
           "options": {
@@ -4905,7 +4920,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4920,7 +4936,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 925
+            "y": 267
           },
           "id": 108,
           "options": {
@@ -5054,7 +5070,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5069,7 +5086,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2099
+            "y": 24
           },
           "id": 142,
           "options": {
@@ -5250,7 +5267,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5265,7 +5283,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2099
+            "y": 24
           },
           "id": 143,
           "options": {
@@ -5444,7 +5462,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5459,7 +5478,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2291
+            "y": 59
           },
           "id": 144,
           "options": {
@@ -5550,7 +5569,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5565,7 +5585,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2291
+            "y": 59
           },
           "id": 145,
           "options": {
@@ -5647,7 +5667,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5662,7 +5683,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2299
+            "y": 67
           },
           "id": 146,
           "options": {
@@ -5797,7 +5818,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5812,7 +5834,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2299
+            "y": 67
           },
           "id": 147,
           "options": {
@@ -5987,7 +6009,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 331
+            "y": 25
           },
           "id": 157,
           "options": {
@@ -6086,7 +6108,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 340
+            "y": 34
           },
           "id": 159,
           "options": {
@@ -6120,13 +6142,123 @@
               "refId": "A"
             }
           ],
-          "title": "GPU Decoder Utlization (%)",
+          "title": "GPU Decoder Utilization (%) per Node",
           "transformations": [
             {
               "id": "renameByRegex",
               "options": {
                 "regex": "(.*):(.*)",
                 "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 43
+          },
+          "id": 160,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Name",
+              "sortDesc": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (instance,card) (rocm_average_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "{{instance}}, {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Decoder Utilization (%) per GPU",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?, (.+)",
+                "renamePattern": "Node/ID: $1/$2"
               }
             }
           ],
@@ -6195,7 +6327,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6210,7 +6343,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5143
+            "y": 1976
           },
           "id": 35,
           "options": {
@@ -6221,12 +6354,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -6317,7 +6451,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5207
+            "y": 1984
           },
           "id": 65,
           "options": {
@@ -6424,7 +6558,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5207
+            "y": 1984
           },
           "id": 66,
           "options": {
@@ -6548,7 +6682,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1836
+            "y": 3930
           },
           "id": 118,
           "options": {
@@ -6656,7 +6790,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2004
+            "y": 4098
           },
           "id": 134,
           "options": {
@@ -6778,7 +6912,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5457
+            "y": 7551
           },
           "id": 92,
           "options": {
@@ -6891,7 +7025,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5465
+            "y": 7559
           },
           "id": 135,
           "options": {
@@ -7000,7 +7134,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5465
+            "y": 7559
           },
           "id": 136,
           "options": {
@@ -7123,7 +7257,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1838
+            "y": 3932
           },
           "id": 121,
           "options": {
@@ -7245,7 +7379,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1846
+            "y": 3940
           },
           "id": 137,
           "options": {
@@ -7354,7 +7488,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1846
+            "y": 3940
           },
           "id": 138,
           "options": {
@@ -7463,7 +7597,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1854
+            "y": 3948
           },
           "id": 148,
           "options": {
@@ -7585,7 +7719,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1862
+            "y": 3956
           },
           "id": 149,
           "options": {
@@ -7694,7 +7828,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1862
+            "y": 3956
           },
           "id": 150,
           "options": {
@@ -7817,7 +7951,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1839
+            "y": 3933
           },
           "id": 115,
           "options": {
@@ -7939,7 +8073,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1847
+            "y": 3941
           },
           "id": 96,
           "options": {
@@ -8048,7 +8182,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1847
+            "y": 3941
           },
           "id": 94,
           "options": {
@@ -8157,7 +8291,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1855
+            "y": 3949
           },
           "id": 93,
           "options": {
@@ -8266,7 +8400,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1855
+            "y": 3949
           },
           "id": 95,
           "options": {
@@ -8375,7 +8509,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1863
+            "y": 3957
           },
           "id": 151,
           "options": {
@@ -8497,7 +8631,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1871
+            "y": 3965
           },
           "id": 152,
           "options": {
@@ -8606,7 +8740,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1871
+            "y": 3965
           },
           "id": 153,
           "options": {
@@ -8715,7 +8849,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1879
+            "y": 3973
           },
           "id": 154,
           "options": {
@@ -8824,7 +8958,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1879
+            "y": 3973
           },
           "id": 155,
           "options": {

--- a/grafana/source/global.json
+++ b/grafana/source/global.json
@@ -1020,7 +1020,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1380
+            "y": 3190
           },
           "id": 110,
           "options": {
@@ -1139,7 +1139,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1380
+            "y": 3190
           },
           "id": 112,
           "options": {
@@ -1263,7 +1263,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2048
+            "y": 3858
           },
           "id": 113,
           "options": {
@@ -1390,7 +1390,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2048
+            "y": 3858
           },
           "id": 140,
           "options": {
@@ -1537,7 +1537,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 2054
+            "y": 3864
           },
           "id": 139,
           "options": {
@@ -1768,7 +1768,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 639
           },
           "id": 99,
           "interval": "5s",
@@ -2038,7 +2038,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 3325
+            "y": 5135
           },
           "id": 12,
           "options": {
@@ -2208,7 +2208,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 3325
+            "y": 5135
           },
           "id": 20,
           "options": {
@@ -2375,7 +2375,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 3753
+            "y": 5563
           },
           "id": 21,
           "options": {
@@ -2580,7 +2580,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 3753
+            "y": 5563
           },
           "id": 22,
           "options": {
@@ -2800,7 +2800,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 14214
+            "y": 16024
           },
           "id": 28,
           "options": {
@@ -3071,7 +3071,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -3083,7 +3084,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 4232
+            "y": 324
           },
           "id": 23,
           "options": {
@@ -3096,11 +3097,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-75826",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3203,7 +3205,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3218,7 +3221,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 545
+            "y": 325
           },
           "id": 26,
           "options": {
@@ -3303,7 +3306,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1202
+            "y": 370
           },
           "id": 6,
           "options": {
@@ -3425,7 +3428,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -3437,7 +3441,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1211
+            "y": 379
           },
           "id": 29,
           "options": {
@@ -3450,12 +3454,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3533,7 +3538,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -3545,7 +3551,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1211
+            "y": 379
           },
           "id": 103,
           "options": {
@@ -3558,12 +3564,13 @@
               "sortDesc": false
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3675,7 +3682,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1386
+            "y": 3196
           },
           "id": 102,
           "options": {
@@ -3791,7 +3798,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1395
+            "y": 3205
           },
           "id": 38,
           "options": {
@@ -3907,7 +3914,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1395
+            "y": 3205
           },
           "id": 39,
           "options": {
@@ -4023,7 +4030,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1404
+            "y": 3214
           },
           "id": 109,
           "options": {
@@ -4145,7 +4152,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 547
+            "y": 2357
           },
           "id": 106,
           "options": {
@@ -4254,7 +4261,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 841
+            "y": 2651
           },
           "id": 119,
           "options": {
@@ -4363,7 +4370,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 850
+            "y": 2660
           },
           "id": 104,
           "options": {
@@ -4471,7 +4478,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 850
+            "y": 2660
           },
           "id": 105,
           "options": {
@@ -4593,7 +4600,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 548
+            "y": 2358
           },
           "id": 124,
           "options": {
@@ -4702,7 +4709,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 824
+            "y": 2634
           },
           "id": 125,
           "options": {
@@ -4812,7 +4819,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4827,7 +4835,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 288
+            "y": 916
           },
           "id": 123,
           "options": {
@@ -4912,7 +4920,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 505
+            "y": 925
           },
           "id": 108,
           "options": {
@@ -5061,7 +5069,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 289
+            "y": 2099
           },
           "id": 142,
           "options": {
@@ -5257,7 +5265,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 289
+            "y": 2099
           },
           "id": 143,
           "options": {
@@ -5451,7 +5459,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 481
+            "y": 2291
           },
           "id": 144,
           "options": {
@@ -5557,7 +5565,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 481
+            "y": 2291
           },
           "id": 145,
           "options": {
@@ -5654,7 +5662,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 489
+            "y": 2299
           },
           "id": 146,
           "options": {
@@ -5804,7 +5812,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 489
+            "y": 2299
           },
           "id": 147,
           "options": {
@@ -5911,6 +5919,231 @@
         "x": 0,
         "y": 24
       },
+      "id": 156,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 331
+          },
+          "id": 157,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg(rocm_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "Decoder",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregate Cluster GPU Decoder Utilization (%)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 340
+          },
+          "id": 159,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Name",
+              "sortDesc": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (instance) (rocm_decoder_utilization_percentage)",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Decoder Utlization (%)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "(.*):(.*)",
+                "renamePattern": "Node: $1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "GPU - Video",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
       "id": 36,
       "panels": [
         {
@@ -5977,7 +6210,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3333
+            "y": 5143
           },
           "id": 35,
           "options": {
@@ -6084,7 +6317,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3397
+            "y": 5207
           },
           "id": 65,
           "options": {
@@ -6191,7 +6424,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3397
+            "y": 5207
           },
           "id": 66,
           "options": {
@@ -6244,7 +6477,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 117,
       "panels": [
@@ -6299,8 +6532,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6316,7 +6548,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 26
+            "y": 1836
           },
           "id": 118,
           "options": {
@@ -6424,7 +6656,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 194
+            "y": 2004
           },
           "id": 134,
           "options": {
@@ -6477,7 +6709,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 27
       },
       "id": 120,
       "panels": [
@@ -6546,7 +6778,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3647
+            "y": 5457
           },
           "id": 92,
           "options": {
@@ -6659,7 +6891,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3655
+            "y": 5465
           },
           "id": 135,
           "options": {
@@ -6768,7 +7000,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3655
+            "y": 5465
           },
           "id": 136,
           "options": {
@@ -6822,7 +7054,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 28
       },
       "id": 116,
       "panels": [
@@ -6875,8 +7107,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6892,7 +7123,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 28
+            "y": 1838
           },
           "id": 121,
           "options": {
@@ -6998,8 +7229,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7015,7 +7245,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 1846
           },
           "id": 137,
           "options": {
@@ -7108,8 +7338,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7125,7 +7354,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 1846
           },
           "id": 138,
           "options": {
@@ -7218,8 +7447,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7235,7 +7463,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 1854
           },
           "id": 148,
           "options": {
@@ -7341,8 +7569,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7358,7 +7585,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 1862
           },
           "id": 149,
           "options": {
@@ -7451,8 +7678,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7468,7 +7694,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 1862
           },
           "id": 150,
           "options": {
@@ -7522,7 +7748,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 29
       },
       "id": 67,
       "panels": [
@@ -7575,8 +7801,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7592,7 +7817,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 29
+            "y": 1839
           },
           "id": 115,
           "options": {
@@ -7698,8 +7923,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7715,7 +7939,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 1847
           },
           "id": 96,
           "options": {
@@ -7808,8 +8032,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7825,7 +8048,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 1847
           },
           "id": 94,
           "options": {
@@ -7918,8 +8141,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -7935,7 +8157,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 1855
           },
           "id": 93,
           "options": {
@@ -8028,8 +8250,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8045,7 +8266,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 1855
           },
           "id": 95,
           "options": {
@@ -8138,8 +8359,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8155,7 +8375,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 53
+            "y": 1863
           },
           "id": 151,
           "options": {
@@ -8261,8 +8481,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8278,7 +8497,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 1871
           },
           "id": 152,
           "options": {
@@ -8371,8 +8590,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8388,7 +8606,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 1871
           },
           "id": 153,
           "options": {
@@ -8481,8 +8699,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8498,7 +8715,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 69
+            "y": 1879
           },
           "id": 154,
           "options": {
@@ -8591,8 +8808,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8608,7 +8824,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 69
+            "y": 1879
           },
           "id": 155,
           "options": {

--- a/grafana/source/global.json
+++ b/grafana/source/global.json
@@ -6012,7 +6012,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg(rocm_decoder_utilization_percentage)",
+              "expr": "avg(rocm_average_decoder_utilization_percentage)",
               "instant": false,
               "legendFormat": "Decoder",
               "range": true,
@@ -6113,7 +6113,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance) (rocm_decoder_utilization_percentage)",
+              "expr": "avg by (instance) (rocm_average_decoder_utilization_percentage)",
               "instant": false,
               "legendFormat": "{{instance}}",
               "range": true,

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -93,9 +93,7 @@ class Monitor:
         self.runtimeConfig["collector_power_capping"] = config["omnistat.collectors"].getboolean(
             "enable_power_cap", False
         )
-        self.runtimeConfig["collector_vcn"] = config["omnistat.collectors"].getboolean(
-            "enable_vcn", False
-        )
+        self.runtimeConfig["collector_vcn"] = config["omnistat.collectors"].getboolean("enable_vcn", False)
 
         self.runtimeConfig["collector_enable_rocprofiler"] = config["omnistat.collectors"].getboolean(
             "enable_rocprofiler", False

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -93,6 +93,9 @@ class Monitor:
         self.runtimeConfig["collector_power_capping"] = config["omnistat.collectors"].getboolean(
             "enable_power_cap", False
         )
+        self.runtimeConfig["collector_vcn"] = config["omnistat.collectors"].getboolean(
+            "enable_vcn", False
+        )
 
         self.runtimeConfig["collector_enable_rocprofiler"] = config["omnistat.collectors"].getboolean(
             "enable_rocprofiler", False


### PR DESCRIPTION
Initial implementation to track encoder/decoder utilization. It looks like only decoder utilization is currently supported by amd-smi, and it only works with MI3xx.

Decoder utilization is measured using `vcn_activity`, which reports 4 utilization values. The amd-smi CLI averages the 4 values to provide an aggregated decoder utilization. We can follow the same approach, but for now this PR keeps track of each engine with a different label:
```
rocm_decoder_utilization_percentage{card="0",engine="0"} 0.0
rocm_decoder_utilization_percentage{card="0",engine="1"} 0.0
rocm_decoder_utilization_percentage{card="0",engine="2"} 0.0
rocm_decoder_utilization_percentage{card="0",engine="3"} 0.0
```

Tasks / To be decided:
- [x] Testing with Navi21: `vcn_activity` reports 4 values, first one valid and remaining ones N/A. In this scenario the exporter will only provide samples for the first engine.
- [x] Testing with MI2xx: `vcn_activity` reports 4 values, all of them N/A. In this scenario the exporter won't provide any samples.
- [x] Testing with MI300: `vcn_activity` reports 4 values, all of them valid.
- [x] Testing with MI325: `vcn_activity` reports 4 values, all of them valid.
- [x] Executed decoding sample from rocDecode in MI300, and observed activity in one of the engines.
- [x] Executed decoding sample from rocDecode in MI325, and generated Omnistat traces.
- [x] Decide metric name: for now `rocm_decoder_utilization_percentage`. Using `rocm_vcn_utilization_percentage` would be closer to the source metric we are getting.
- [x] Decide flag name: for now `enable_vcn`. VCN isn't immediately obvious. Could use `enable_decoder` instead, but that means we'll need `enable_encoder` in the future. Another options is using something more generic like `enable_media`.
- [x] Decide whether to aggregate and average utilization or track individual engines: for now track individual engines.
- [x] Add VCN collector to documentation.
- [x] Add panels to global dashboard.

Observations:
- It's still unclear how encoder utilization will be supported in the future.
- `vcn_activity` is documented as: "List of VCN encode/decode engine utilization per AID".
- As the name suggests, `rocDecode` is only for decoding. I haven't found a sample application for encoding; not sure one exists, or how much is supported/accelerated in hardware for encoding purposes.
- In `amd-smi`, encoding appears in the output but it doesn't do anything, it's always N/A: https://github.com/ROCm/amdsmi/blob/a2b11f91172d92235798a00d82af49700eb5f6de/amdsmi_cli/amdsmi_commands.py#L5541-L5570
- Made some changes to the code to avoid finding out what each metric is like during sampling. With the changes, there are different metrics (with different labels) that are treated differently. This way it's easier to deal with the decoder utilization, which is actually a list of values and not a single value like all other metrics.
- The same approach we use for VCN/decoder utilization can also be used for JPEG utilization. Instead of returning 4 values, `jpeg_activity` reports 32 values.
- `amd-smi` also provides `average_mm_activity` for multimedia engine usage, but that seems to be for older architectures and returns `N/A` in MI300.