### PR TITLE
Ignore exceptions when reading cu_occupancy files

### DIFF
--- a/omnistat/utils.py
+++ b/omnistat/utils.py
@@ -240,9 +240,15 @@ def get_occupancy(guid):
 
     cu_occupancy = 0
     for cu_file in list(base_path.glob(file_pattern)):
-        with open(cu_file, "r") as f:
-            data = f.read().strip()
-        cu_occupancy += int(data)
+        try:
+            with open(cu_file, "r") as f:
+                value = f.read().strip()
+            cu_occupancy += int(value)
+        except Exception:
+            # Ignore issues while reading cu_occupancy files. A common reason
+            # that triggers an exception is when the file is no longer there
+            # because the process ended.
+            pass
 
     return cu_occupancy
 


### PR DESCRIPTION
Read files in try block to ignore exceptions.

This fixes an issue in the CU collector that will lead to Omnistat crashing when a reading a `cu_occupancy` file is no longer present because the process ended while sampling.

The assumption here is that a failure to read a `cu_occupancy` means the value is 0 and can be ignored.