### PR TITLE
Update vendor labels and document vendor metrics

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -108,14 +108,19 @@ After job completion, transfer the archived Omnistat data to your local machine
 for analysis using the Docker environment described in the [user-mode
 guide](installation/user-mode.md#exploring-results-locally).
 
-### Vendor Counters
+### Additional Metrics
+
+Frontier exposes an additional site‑specific collector beyond the standard set
+documented in the main [metrics](metrics) reference.
+
+#### Vendor Counters
 
 The vendor counters collector surfaces power and energy telemetry made
-available by site‑specific platform integrations (on Frontier this is the
-Cray/HPE EX `pm_counters` interface). It translates raw counter files into
-metrics that distinguish cumulative energy and instantaneous power samples for
-different components. GPU metrics from this collector are indexed using the
-`accel` label, and isn't guaranteed to match ROCm's GPU device indexing.
+available by site‑specific platform integrations (on Frontier this is the HPE
+Cray `pm_counters` interface). It translates raw counter files into metrics
+that distinguish cumulative energy and instantaneous power samples for
+different components. GPU metrics are indexed by an `accel` label; this index
+may differ from the ordering used by ROCm.
 
 **Collector**: `enable_vendor_counters`
 

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -107,3 +107,28 @@ local filesystems like `/tmp`. Data can't be stored directly under Frontier's
 After job completion, transfer the archived Omnistat data to your local machine
 for analysis using the Docker environment described in the [user-mode
 guide](installation/user-mode.md#exploring-results-locally).
+
+### Vendor Counters
+
+The vendor counters collector surfaces power and energy telemetry made
+available by site‑specific platform integrations (on Frontier this is the
+Cray/HPE EX `pm_counters` interface). It translates raw counter files into
+metrics that distinguish cumulative energy and instantaneous power samples for
+different components. GPU metrics from this collector are indexed using the
+`accel` label, and isn't guaranteed to match ROCm's GPU device indexing.
+
+**Collector**: `enable_vendor_counters`
+
+| Node Metric                            | Description |
+| :------------------------------------- | :---------- |
+| `omnistat_vendor_energy_joules`        | Total node energy consumption (J). Labels: `vendor`. |
+| `omnistat_vendor_power_watts`          | Instantaneous total node power draw (W). Labels: `vendor`. |
+| `omnistat_vendor_cpu_energy_joules`    | Cumulative CPU energy (J). Labels: `vendor`. |
+| `omnistat_vendor_cpu_power_watts`      | Instantaneous CPU power (W). Labels: `vendor`. |
+| `omnistat_vendor_memory_energy_joules` | Cumulative system memory energy (J). Labels: `vendor`. |
+| `omnistat_vendor_memory_power_watts`   | Instantaneous system memory power (W). Labels: `vendor`. |
+
+| GPU Metric                             | Description |
+| :------------------------------------- | :---------- |
+| `omnistat_vendor_accel_energy_joules`  | Cumulative accelerator (GPU) energy (J) for each device. Labels: `vendor`, `accel`. |
+| `omnistat_vendor_accel_power_watts`    | Instantaneous accelerator (GPU) power (W) for each device. Labels: `vendor`, `accel`. |

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -111,15 +111,15 @@ guide](installation/user-mode.md#exploring-results-locally).
 ### Additional Metrics
 
 Frontier exposes an additional site‑specific collector beyond the standard set
-documented in the main [metrics](metrics) reference.
+documented in the main [metrics](metrics) overview.
 
 #### Vendor Counters
 
-The vendor counters collector surfaces power and energy telemetry made
-available by site‑specific platform integrations (on Frontier this is the HPE
-Cray `pm_counters` interface). It translates raw counter files into metrics
+The vendor collector ingests additional telemetry made
+possible by site‑specific platform integrations. On Frontier, this collector leverages the HPE
+Cray `pm_counters` interface and translates raw counter files into metrics
 that distinguish cumulative energy and instantaneous power samples for
-different components. GPU metrics are indexed by an `accel` label; this index
+different node-level components. Note that GPU metrics are indexed by an `accel` label and this index
 may differ from the ordering used by ROCm.
 
 **Collector**: `enable_vendor_counters`

--- a/omnistat/collector_pm_counters.py
+++ b/omnistat/collector_pm_counters.py
@@ -99,7 +99,7 @@ class PM_COUNTERS(Collector):
                             gauge = definedMetrics[metric_name]
                         else:
                             description = f"GPU {match.group(3)} ({units_short})"
-                            gauge = Gauge(self.__prefix + metric_name, description, labelnames=["card", "vendor"])
+                            gauge = Gauge(self.__prefix + metric_name, description, labelnames=["accel", "vendor"])
                             definedMetrics[metric_name] = gauge
                             logging.info(
                                 "--> [Registered] %s -> %s (gauge)" % (self.__prefix + metric_name, description)
@@ -138,7 +138,7 @@ class PM_COUNTERS(Collector):
             try:
                 with open(filePath, "r") as f:
                     data = f.readline().strip().split()
-                    gaugeMetric.labels(card=gpuIndex, vendor=self.__vendor).set(data[0])
+                    gaugeMetric.labels(accel=gpuIndex, vendor=self.__vendor).set(data[0])
 
             except:
                 pass

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -1196,12 +1196,14 @@ class QueryMetrics:
             (
                 "vendor",
                 ["omnistat_vendor_accel_energy_joules", " omnistat_vendor_accel_power_watts"],
-                ["instance", "card", "vendor"],
+                ["instance", "accel", "vendor"],
             ),
         ]
 
         for name, metrics, labels in exports:
-            extension = ".gpu.csv" if "card" in labels else ".csv"
+            extension = ".csv"
+            if "card" in labels or "accel" in labels:
+                extension = ".gpu.csv"
             export_file = f"{export_path}/{export_prefix}{name}{extension}"
             self.export_metrics(export_file, metrics, labels)
 


### PR DESCRIPTION
- [x] Avoid using `card` for vendor labels since the indexing doesn't necessarily match the GPU indexing in ROCm.
- [x] Add vendor metrics to documentation.
