### PR TITLE
Support for device counting with rocprofiler-sdk

### DIFF
--- a/rocprofiler-sdk/CMakeLists.txt
+++ b/rocprofiler-sdk/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.15)
+project(omnistat_rocprofiler_sdk_extension LANGUAGES CXX)
+
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+
+set(CMAKE_EXECUTE_PROCESS_COMMAND_ECHO STDOUT)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+
+find_package(nanobind CONFIG REQUIRED)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+nanobind_add_module(rocprofiler_sdk_extension device.cpp binding.cpp)
+target_link_libraries(rocprofiler_sdk_extension PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+
+# Install the module to location within the Python package
+install(TARGETS rocprofiler_sdk_extension LIBRARY DESTINATION omnistat/rocprofiler)

--- a/rocprofiler-sdk/binding.cpp
+++ b/rocprofiler-sdk/binding.cpp
@@ -1,0 +1,27 @@
+#include "device.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/bind_vector.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+NB_MODULE(rocprofiler_sdk_extension, m) {
+    m.doc() = "Omnistat's ROCProfiler-SDK device sampling module";
+
+    m.def("initialize", &omnistat::initialize);
+
+    nb::bind_vector<std::vector<std::string>>(m, "StringList");
+    nb::bind_vector<std::vector<double>>(m, "DoubleList");
+
+    nb::class_<omnistat::DeviceSampler>(m, "DeviceSampler")
+        .def("start", &omnistat::DeviceSampler::start, "counters"_a)
+        .def("sample", &omnistat::DeviceSampler::sample)
+        .def("stop", &omnistat::DeviceSampler::stop);
+
+    nb::bind_vector<std::vector<std::shared_ptr<omnistat::DeviceSampler>>>(m, "DeviceSamplerList");
+
+    m.def("get_samplers", &omnistat::get_samplers);
+}

--- a/rocprofiler-sdk/device.cpp
+++ b/rocprofiler-sdk/device.cpp
@@ -1,0 +1,239 @@
+#include "device.hpp"
+
+#include <hsa/hsa.h>
+#include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/registration.h>
+
+#include <iostream>
+#include <sstream>
+
+#define ROCPROFILER_CALL(result, msg)                                                              \
+    {                                                                                              \
+        rocprofiler_status_t CHECKSTATUS = result;                                                 \
+        if (CHECKSTATUS != ROCPROFILER_STATUS_SUCCESS) {                                           \
+            std::string status_msg = rocprofiler_get_status_string(CHECKSTATUS);                   \
+            std::cerr << "[" #result "][" << __FILE__ << ":" << __LINE__ << "] " << msg            \
+                      << " failed with error code " << CHECKSTATUS << ": " << status_msg           \
+                      << std::endl;                                                                \
+            std::stringstream errmsg{};                                                            \
+            errmsg << "[" #result "][" << __FILE__ << ":" << __LINE__ << "] " << msg " failure ("  \
+                   << status_msg << ")";                                                           \
+            throw std::runtime_error(errmsg.str());                                                \
+        }                                                                                          \
+    }
+
+namespace omnistat {
+
+// Global variable to keep track of samplers, necessary because it needs to be initialized and used
+// by different entities. Samplers and rocprofiler contexts are initialized while rocprofiler is
+// being configured, which isn't directly under our control.
+static std::vector<std::shared_ptr<DeviceSampler>> samplers = {};
+
+const std::vector<std::shared_ptr<DeviceSampler>> &get_samplers() {
+    return samplers;
+}
+
+// Initialization required to use the extension. ROCProfiler-SDK normally expects to be loaded as
+// part of an application with GPU code, e.g. HIP. This Python extension doesn't execute anything in
+// the GPU, so we need to force its initialization. HSA also needs to be initialized to set up the
+// right queues for device profiling.
+void initialize() {
+    ROCPROFILER_CALL(rocprofiler_force_configure(&rocprofiler_configure), "configure rocprofiler");
+    hsa_init();
+}
+
+std::vector<rocprofiler_agent_v0_t> get_rocprofiler_agents() {
+    std::vector<rocprofiler_agent_v0_t> agents;
+    rocprofiler_query_available_agents_cb_t iterate_cb = [](rocprofiler_agent_version_t agents_ver,
+                                                            const void **agents_arr,
+                                                            size_t num_agents, void *udata) {
+        if (agents_ver != ROCPROFILER_AGENT_INFO_VERSION_0)
+            throw std::runtime_error{"unexpected rocprofiler agent version"};
+        auto *agents_v = static_cast<std::vector<rocprofiler_agent_v0_t> *>(udata);
+        for (size_t i = 0; i < num_agents; ++i) {
+            const auto *rocp_agent = static_cast<const rocprofiler_agent_v0_t *>(agents_arr[i]);
+            if (rocp_agent->type == ROCPROFILER_AGENT_TYPE_GPU)
+                agents_v->emplace_back(*rocp_agent);
+        }
+        return ROCPROFILER_STATUS_SUCCESS;
+    };
+
+    ROCPROFILER_CALL(rocprofiler_query_available_agents(
+                         ROCPROFILER_AGENT_INFO_VERSION_0, iterate_cb, sizeof(rocprofiler_agent_t),
+                         const_cast<void *>(static_cast<const void *>(&agents))),
+                     "query available agents");
+    return agents;
+}
+
+// Calculate the size of a given counter based on its dimensions. GPU counters aren't simple
+// scalars: counters might exist per SE, CU, etc. and are reported as separate records by
+// ROCProfiler-SDK.
+size_t get_counter_size(rocprofiler_counter_id_t counter) {
+    size_t size = 1;
+    rocprofiler_iterate_counter_dimensions(
+        counter,
+        [](rocprofiler_counter_id_t, const rocprofiler_record_dimension_info_t *dim_info,
+           size_t num_dims, void *user_data) {
+            size_t *s = static_cast<size_t *>(user_data);
+            for (size_t i = 0; i < num_dims; i++) {
+                *s *= dim_info[i].instance_size;
+            }
+            return ROCPROFILER_STATUS_SUCCESS;
+        },
+        static_cast<void *>(&size));
+    return size;
+}
+
+DeviceSampler::DeviceSampler(rocprofiler_agent_id_t agent) : agent_(agent) {
+    ROCPROFILER_CALL(rocprofiler_create_context(&ctx_), "create context");
+
+    ROCPROFILER_CALL(rocprofiler_configure_device_counting_service(
+                         ctx_, rocprofiler_buffer_id_t{.handle = 0}, agent,
+                         [](rocprofiler_context_id_t context_id, rocprofiler_agent_id_t,
+                            rocprofiler_agent_set_profile_callback_t set_config, void *user_data) {
+                             if (user_data) {
+                                 auto *sampler = static_cast<DeviceSampler *>(user_data);
+                                 sampler->set_profile(context_id, set_config);
+                             }
+                         },
+                         this),
+                     "device counting service");
+}
+
+void DeviceSampler::set_profile(rocprofiler_context_id_t ctx,
+                                rocprofiler_agent_set_profile_callback_t cb) const {
+    if (profile_.handle != 0) {
+        ROCPROFILER_CALL(cb(ctx, profile_), "set profile callback");
+    }
+}
+
+std::unordered_map<std::string, rocprofiler_counter_id_t>
+DeviceSampler::get_supported_counters() const {
+    std::unordered_map<std::string, rocprofiler_counter_id_t> out;
+    std::vector<rocprofiler_counter_id_t> gpu_counters;
+
+    ROCPROFILER_CALL(rocprofiler_iterate_agent_supported_counters(
+                         agent_,
+                         [](rocprofiler_agent_id_t, rocprofiler_counter_id_t *counters,
+                            size_t num_counters, void *user_data) {
+                             std::vector<rocprofiler_counter_id_t> *vec =
+                                 static_cast<std::vector<rocprofiler_counter_id_t> *>(user_data);
+                             for (size_t i = 0; i < num_counters; i++) {
+                                 vec->push_back(counters[i]);
+                             }
+                             return ROCPROFILER_STATUS_SUCCESS;
+                         },
+                         static_cast<void *>(&gpu_counters)),
+                     "iterate supported counters");
+    for (auto &counter : gpu_counters) {
+        rocprofiler_counter_info_v0_t version;
+        ROCPROFILER_CALL(rocprofiler_query_counter_info(counter, ROCPROFILER_COUNTER_INFO_VERSION_0,
+                                                        static_cast<void *>(&version)),
+                         "query counter");
+        out.emplace(version.name, counter);
+    }
+    return out;
+}
+
+void DeviceSampler::start(const std::vector<std::string> &counters) {
+    rocprofiler_profile_config_id_t profile = {};
+    std::size_t profile_size = 0;
+
+    auto cached_profile = cached_profiles_.find(counters);
+    if (cached_profile == cached_profiles_.end()) {
+        std::vector<rocprofiler_counter_id_t> counter_ids;
+
+        auto supported_counters = get_supported_counters();
+        for (const auto &counter : counters) {
+            auto it = supported_counters.find(counter);
+            if (it == supported_counters.end()) {
+                throw std::runtime_error("Unsupported counter: " + counter);
+            }
+
+            profile_size += get_counter_size(it->second);
+            counter_ids.push_back(it->second);
+        }
+
+        ROCPROFILER_CALL(rocprofiler_create_profile_config(agent_, counter_ids.data(),
+                                                           counter_ids.size(), &profile),
+                         "create profile");
+
+        cached_profiles_.emplace(counters, profile);
+        profile_sizes_.emplace(profile.handle, profile_size);
+        profile_counter_ids_.emplace(profile.handle, counter_ids);
+    } else {
+        profile = cached_profile->second;
+        profile_size = profile_sizes_[profile.handle];
+    }
+
+    profile_ = profile;
+    records_.resize(profile_size);
+    ROCPROFILER_CALL(rocprofiler_start_context(ctx_), "start context");
+}
+
+void DeviceSampler::stop() {
+    ROCPROFILER_CALL(rocprofiler_stop_context(ctx_), "stop context");
+}
+
+std::vector<double> DeviceSampler::sample() {
+    std::vector<double> result;
+    std::unordered_map<rocprofiler_counter_instance_id_t, double> aggregate;
+
+    size_t size = records_.size();
+    rocprofiler_sample_device_counting_service(ctx_, {}, ROCPROFILER_COUNTER_FLAG_NONE,
+                                               records_.data(), &size);
+
+    // If the user is requesting non-aggregated counters, such as SQ_WAVES instead of SQ_WAVES_sum,
+    // this extension sums all records in an attempt to return a value that represents total
+    // activity.
+    rocprofiler_counter_id_t counter_id = {.handle = 0};
+    for (const auto &record : records_) {
+        rocprofiler_query_record_counter_id(record.id, &counter_id);
+        aggregate[counter_id.handle] += record.counter_value;
+    }
+
+    const auto counter_ids = profile_counter_ids_[profile_.handle];
+    for (const auto &counter_id : counter_ids) {
+        result.push_back(aggregate[counter_id.handle]);
+    }
+
+    return result;
+}
+
+} // namespace omnistat
+
+// ------------------------------------------------------------------------------------------------
+// ROCProfiler SDK tool initialization
+// ------------------------------------------------------------------------------------------------
+
+int tool_init(rocprofiler_client_finalize_t fini_func, void *) {
+    auto agents = omnistat::get_rocprofiler_agents();
+    if (agents.empty()) {
+        std::cerr << "No agents found\n";
+        return -1;
+    }
+
+    for (auto agent : agents) {
+        omnistat::samplers.push_back(std::make_shared<omnistat::DeviceSampler>(agent.id));
+    }
+
+    return 0;
+}
+
+void tool_fini(void *user_data) {
+    omnistat::samplers.clear();
+}
+
+extern "C" rocprofiler_tool_configure_result_t *rocprofiler_configure(uint32_t version,
+                                                                      const char *runtime_version,
+                                                                      uint32_t priority,
+                                                                      rocprofiler_client_id_t *id) {
+    id->name = "omnistat-rocprofiler-sdk-extension";
+
+    std::ostream *output_stream = &std::cout;
+    static auto cfg =
+        rocprofiler_tool_configure_result_t{sizeof(rocprofiler_tool_configure_result_t), &tool_init,
+                                            &tool_fini, static_cast<void *>(output_stream)};
+
+    return &cfg;
+}

--- a/rocprofiler-sdk/device.hpp
+++ b/rocprofiler-sdk/device.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <rocprofiler-sdk/rocprofiler.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace omnistat {
+
+class DeviceSampler {
+  public:
+    DeviceSampler(rocprofiler_agent_id_t agent);
+
+    void start(const std::vector<std::string> &counters);
+    void stop();
+
+    std::vector<double> sample();
+
+  private:
+    rocprofiler_agent_id_t agent_ = {};
+
+    rocprofiler_context_id_t ctx_ = {.handle = 0};
+    rocprofiler_profile_config_id_t profile_ = {.handle = 0};
+
+    std::map<std::vector<std::string>, rocprofiler_profile_config_id_t> cached_profiles_;
+
+    // Store sizes and counter IDs for each profile. Sizes for each profile ID
+    // are used to update the record buffer when the profile changes. The list of
+    // counter IDs is used to aggregate and return counter values in the same
+    // order they are requested.
+    std::unordered_map<uint64_t, uint64_t> profile_sizes_;
+    std::unordered_map<uint64_t, std::vector<rocprofiler_counter_id_t>> profile_counter_ids_;
+
+    // Buffer records from last sample; its size changes every time a new
+    // profile is started
+    std::vector<rocprofiler_record_counter_t> records_;
+
+    void set_profile(rocprofiler_context_id_t ctx,
+                     rocprofiler_agent_set_profile_callback_t cb) const;
+    std::unordered_map<std::string, rocprofiler_counter_id_t> get_supported_counters() const;
+};
+
+void initialize();
+
+const std::vector<std::shared_ptr<DeviceSampler>> &get_samplers();
+
+} // namespace omnistat


### PR DESCRIPTION
This PR introduces a Python extension that provides access to AMD GPU performance counters through ROCProfiler-SDK, and a new collector for Omnistat based on it. It addresses some limitations of the old ROCProfiler collector, and allows much more flexible counter collection.

Tasks:
- [x] Python extension for device counting with ROCProfiler-SDK.
- [x] Allow setting counters to be sampled on a per-GPU basis.
- [x] Allow changing counters over time.
- [ ] Build extension as part of installation.
- [ ] Omnistat collector based on the extension.
- [ ] Configurable sets of counters.
- [ ] Distribution schemes to cycle sets of counters through nodes, GPUs, or GPU IDs.