### PR TITLE
Add requests to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ Flask>=2.3.2
 prometheus_client>=0.17.0
 gunicorn>=21.2.0
 packaging>=24.1
+requests
 setuptools-git-versioning>=2.0,<3


### PR DESCRIPTION
The `requests` package is needed for standalone monitoring, but it was missing from dependencies.

An alternative to requiring it for every installation is creating a separate list of dependencies for standalone monitoring (similar to query).