### PR TITLE
Remove max Python version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "omnistat"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 readme = "README.md"
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.8"
 
 [project.scripts]
 omnistat-monitor = "omnistat.node_monitoring:main"


### PR DESCRIPTION
Removing the requirement for Python <3.11. There used to be some issues with Python 3.11/3.12 and some of Omnistat's dependencies, but everything seems to be working as expected now.