### PR TITLE
updates for omnistat-query export mode

### DIFF
--- a/docs/installation/user-mode.md
+++ b/docs/installation/user-mode.md
@@ -279,6 +279,7 @@ following table.
 | `omnistat-network.csv`          | `network`                    | Network interface rx/tx bytes.                            |
 | `omnistat-host.csv`             | `host_metrics`               | Host CPU, memory, and local I/O metrics.                  |
 | `omnistat-host-proc-io.csv`     | `host_metrics`               | Per-process I/O (includes network I/O).                   |
+| `omnistat-host-proc-io-inventory.csv` | `host_metrics`         | PID inventory with per-process start/end times and total bytes read/written. |
 | `omnistat-rocprofiler.gpu.csv`  | `rocprofiler`                | GPU hardware performance counters.                        |
 | `omnistat-fom.csv`              | `fom`                        | Figures of merit.                                         |
 | `omnistat-vendor.csv`           | `vendor_counters`            | Node-level vendor PM counters (energy, power).            |

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -233,7 +233,7 @@ class UserBasedMonitoring:
         utils.runBGProcess(command, outputFile=vm_logfile, envAdds=envAddition)
 
         # Check VictoriaMetrics is ready to accept data. Extra sleeps added here
-        # to deal with occasional slow startup observed on shared file systems 
+        # to deal with occasional slow startup observed on shared file systems
         # like Lustre.
         health_url = "http://localhost:9090/ready"
         elapsed = 0

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -38,6 +38,7 @@ import tempfile
 import time
 from pathlib import Path
 
+import requests
 import yaml
 
 from omnistat import utils
@@ -230,6 +231,25 @@ class UserBasedMonitoring:
 
         logging.info("Server start command: %s" % command)
         utils.runBGProcess(command, outputFile=vm_logfile, envAdds=envAddition)
+
+        # Check VictoriaMetrics is ready to accept data. Extra sleeps added here
+        # to deal with occasional slow startup observed on shared file systems 
+        # like Lustre.
+        health_url = "http://localhost:9090/ready"
+        elapsed = 0
+        for delay in [1, 2, 4, 8]:
+            time.sleep(delay)
+            elapsed += delay
+            try:
+                response = requests.get(health_url, timeout=2)
+                if response.status_code == 200:
+                    logging.info("VictoriaMetrics is responsive (after %ds)" % elapsed)
+                    break
+            except requests.exceptions.RequestException:
+                pass
+            logging.info("VictoriaMetrics not yet responsive (%ds elapsed)" % elapsed)
+        else:
+            logging.warning("VictoriaMetrics not responsive after %ds, proceeding." % elapsed)
 
     def startPromServer(self, victoriaMode=True):
 

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -441,6 +441,7 @@ class UserBasedMonitoring:
                 ssh_timeout=100,
                 max_retries=3,
                 retry_delay=5,
+                process_guard="omnistat.standalone",
             )
             self._log_ssh_parallel_timing(
                 launch_results, label="exporter launch", total_elapsed=time.perf_counter() - t_launch_start

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -1668,13 +1668,15 @@ class QueryMetrics:
 
                 timestamps = [datetime.fromtimestamp(float(v[0])) for v in series["values"]]
                 if timestamps:
-                    rows.append({
-                        "instance": instance,
-                        "pid": pid,
-                        "cmd": cmd,
-                        "start_time": min(timestamps),
-                        "end_time": max(timestamps),
-                    })
+                    rows.append(
+                        {
+                            "instance": instance,
+                            "pid": pid,
+                            "cmd": cmd,
+                            "start_time": min(timestamps),
+                            "end_time": max(timestamps),
+                        }
+                    )
 
         if rows:
             df = pandas.DataFrame(rows)

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -1642,17 +1642,18 @@ class QueryMetrics:
         """Export a PID inventory for proc-io metrics.
 
         Produces a lightweight CSV listing each unique process observed during
-        the job, with its first and last seen timestamps. Columns:
-        instance, pid, cmd, start_time, end_time
+        the job, with its first and last seen timestamps and total bytes
+        read/written. Columns:
+        instance, pid, cmd, start_time, end_time, read_bytes, write_bytes
 
         Args:
             output_file (string): path to output CSV file
             metrics (list): list of proc-io metric names to scan
         """
 
-        rows = []
-        seen = set()
+        inventory = {}
         for metric in metrics:
+            is_read = "read" in metric
             query = "%s * on (instance) group_left() (max by (instance) (rmsjob_info{$job,$step}))" % metric
             metric_data = self.query_job_range(query)
 
@@ -1662,24 +1663,37 @@ class QueryMetrics:
                 pid = labels.get("pid", "")
                 cmd = labels.get("cmd", "")
                 key = (instance, pid, cmd)
-                if key in seen:
+
+                values = series["values"]
+                if not values:
                     continue
-                seen.add(key)
 
-                timestamps = [datetime.fromtimestamp(float(v[0])) for v in series["values"]]
-                if timestamps:
-                    rows.append(
-                        {
-                            "instance": instance,
-                            "pid": pid,
-                            "cmd": cmd,
-                            "start_time": min(timestamps),
-                            "end_time": max(timestamps),
-                        }
-                    )
+                timestamps = [datetime.fromtimestamp(float(v[0])) for v in values]
+                total_bytes = max(0, float(values[-1][1]) - float(values[0][1]))
 
-        if rows:
-            df = pandas.DataFrame(rows)
+                if key not in inventory:
+                    inventory[key] = {
+                        "instance": instance,
+                        "pid": pid,
+                        "cmd": cmd,
+                        "start_time": min(timestamps),
+                        "end_time": max(timestamps),
+                        "read_bytes": 0,
+                        "write_bytes": 0,
+                    }
+                else:
+                    inventory[key]["start_time"] = min(inventory[key]["start_time"], min(timestamps))
+                    inventory[key]["end_time"] = max(inventory[key]["end_time"], max(timestamps))
+
+                if is_read:
+                    inventory[key]["read_bytes"] = total_bytes
+                else:
+                    inventory[key]["write_bytes"] = total_bytes
+
+        if inventory:
+            df = pandas.DataFrame(inventory.values())
+            df["read_bytes"] = df["read_bytes"].round().astype(int)
+            df["write_bytes"] = df["write_bytes"].round().astype(int)
             df = df.sort_values(["instance", "start_time", "pid"])
             df.to_csv(output_file, index=False)
 

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -967,7 +967,6 @@ class QueryMetrics:
         print("")
         print("--")
         print("Query interval = %.3f secs" % self.interval)
-        print("Query execution time = %.1f secs" % (timeit.default_timer() - self.timer_start))
         print("Version = %s" % self.version)
         return
 
@@ -1816,6 +1815,8 @@ def main():
 
         export_path.mkdir(exist_ok=True)
         query.export(export_path)
+
+    print("Query execution time = %.1f secs" % (timeit.default_timer() - query.timer_start))
 
 
 if __name__ == "__main__":

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -1579,7 +1579,7 @@ class QueryMetrics:
 
         return
 
-    def export_metrics(self, output_file, metrics, pivot_labels):
+    def export_metrics(self, output_file, metrics, pivot_labels, aggregation=None):
         """Export time series for given metrics as a CSV file.
 
         Organize columns hierarchically, aligning timestamps and allowing
@@ -1599,13 +1599,19 @@ class QueryMetrics:
             output_file (string): path to output CSV file
             metrics (list): list of metrics to export
             pivot_labels (list): list of labels to use for hierarchical indexing
+            aggregation (string): optional PromQL aggregation to apply before the join
+                                  (e.g., "sum by (instance)")
         """
 
         index = ["timestamp"] + pivot_labels
 
         metric_dfs = []
         for metric in metrics:
-            query = "%s * on (instance) group_left() (max by (instance) (rmsjob_info{$job,$step}))" % (metric)
+            if aggregation:
+                metric_expr = "%s (%s)" % (aggregation, metric)
+            else:
+                metric_expr = metric
+            query = "%s * on (instance) group_left() (max by (instance) (rmsjob_info{$job,$step}))" % (metric_expr)
             metric_data = self.query_job_range(query)
 
             if len(metric_data) == 0:
@@ -1631,6 +1637,49 @@ class QueryMetrics:
         if len(metric_dfs) > 0:
             df = pandas.concat(metric_dfs, axis=1)
             df.to_csv(output_file)
+
+    def export_proc_io_inventory(self, output_file, metrics):
+        """Export a PID inventory for proc-io metrics.
+
+        Produces a lightweight CSV listing each unique process observed during
+        the job, with its first and last seen timestamps. Columns:
+        instance, pid, cmd, start_time, end_time
+
+        Args:
+            output_file (string): path to output CSV file
+            metrics (list): list of proc-io metric names to scan
+        """
+
+        rows = []
+        seen = set()
+        for metric in metrics:
+            query = "%s * on (instance) group_left() (max by (instance) (rmsjob_info{$job,$step}))" % metric
+            metric_data = self.query_job_range(query)
+
+            for series in metric_data:
+                labels = series["metric"]
+                instance = labels.get("instance", "")
+                pid = labels.get("pid", "")
+                cmd = labels.get("cmd", "")
+                key = (instance, pid, cmd)
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                timestamps = [datetime.fromtimestamp(float(v[0])) for v in series["values"]]
+                if timestamps:
+                    rows.append({
+                        "instance": instance,
+                        "pid": pid,
+                        "cmd": cmd,
+                        "start_time": min(timestamps),
+                        "end_time": max(timestamps),
+                    })
+
+        if rows:
+            df = pandas.DataFrame(rows)
+            df = df.sort_values(["instance", "start_time", "pid"])
+            df.to_csv(output_file, index=False)
 
     def export(self, export_path):
         export_prefix = "omnistat-"
@@ -1700,7 +1749,8 @@ class QueryMetrics:
             (
                 "host-proc-io",
                 ["omnistat_host_io_read_total_bytes", "omnistat_host_io_write_total_bytes"],
-                ["instance", "pid", "cmd"],
+                ["instance"],
+                "sum by (instance)",
             ),
             (
                 "cxi",
@@ -1766,12 +1816,19 @@ class QueryMetrics:
             ),
         ]
 
-        for name, metrics, labels in exports:
+        for entry in exports:
+            name, metrics, labels = entry[0], entry[1], entry[2]
+            aggregation = entry[3] if len(entry) > 3 else None
             extension = ".csv"
             if "card" in labels or "accel" in labels:
                 extension = ".gpu.csv"
             export_file = f"{export_path}/{export_prefix}{name}{extension}"
-            self.export_metrics(export_file, metrics, labels)
+            self.export_metrics(export_file, metrics, labels, aggregation=aggregation)
+
+        # Export proc-io PID inventory (start/end times per process)
+        proc_io_metrics = ["omnistat_host_io_read_total_bytes", "omnistat_host_io_write_total_bytes"]
+        inventory_file = f"{export_path}/{export_prefix}host-proc-io-inventory.csv"
+        self.export_proc_io_inventory(inventory_file, proc_io_metrics)
 
 
 def main():

--- a/omnistat/utils.py
+++ b/omnistat/utils.py
@@ -571,9 +571,15 @@ def execute_ssh_command_nohup(
     retry_delay: float,
     ssh_timeout: float,
     outputDir: str,
+    process_guard: str = None,
 ) -> list[bool, str]:
     """
     Executes a single command on a remote host via ssh with nohup for launching background processes.
+
+    Args:
+        process_guard (str): optional pattern for pgrep to check before launching. When set,
+            retries will skip the launch if a matching process is already running on the remote
+            host, preventing duplicate background processes.
 
     Returns:
         list containing [success_status, output_filename]
@@ -584,7 +590,10 @@ def execute_ssh_command_nohup(
     while attempt <= max_retries:
         try:
             outfile = outputDir + f"/omnistat_launch_{hostname}_try{attempt}.log"
-            nohup_command = f"nohup {command} > {shlex.quote(outfile)} 2>&1 &"
+            if process_guard and attempt > 1:
+                nohup_command = f"pgrep -f {shlex.quote(process_guard)} > /dev/null || nohup {command} > {shlex.quote(outfile)} 2>&1 &"
+            else:
+                nohup_command = f"nohup {command} > {shlex.quote(outfile)} 2>&1 &"
             ssh_command = ["ssh", hostname, "env BASH_ENV= bash --noprofile --norc -c " + shlex.quote(nohup_command)]
 
             logging.debug(f"[pssh] {ssh_command}")
@@ -626,6 +635,7 @@ def execute_ssh_parallel(
     retry_delay: float = 2.0,
     ssh_timeout: float = 10.0,
     outputDir: str = "/tmp",
+    process_guard: str = None,
 ) -> dict:
     """
     Spawn commands on remote servers with nohup on multiple hosts in parallel using native ssh client.
@@ -649,6 +659,7 @@ def execute_ssh_parallel(
                 retry_delay,
                 ssh_timeout,
                 outputDir,
+                process_guard,
             ): host
             for host in hostnames
         }


### PR DESCRIPTION
This PR addresses slow `omnistat-query --export` times observed from a user case on Frontier that spawned many thousands of processes during the job execution.

### Overview

A 64-node job on Frontier spawned more than 180K processes during its job lifetime.  At the end of the job, the user used the `--export` option of `omnistat-query` to query gathered telemetry data and convert to CSV files. The original CSV export logged data on a per-process basis resulting in inefficient sparse output and bloated file size of 687MB. In addition, the conversion was very slow requiring ~15 min to complete.

As a result, this PR adjusts the CSV output schema and now generates two files:

1. `omnistat-host-proc-io.csv` — aggregated I/O totals per node, one row per timestamp per node. Using this updated output, the file size was reduced from 687MB to ~1.9MB.

2. `omnistat-host-proc-io-inventory.csv` — one row per unique process observed during the job, with columns: instance, pid, cmd, start_time, end_time, read_bytes, write_bytes.

With the updated export schema, the export time from this case was reduced to ~79 seconds.

#### Additional changes

* SSH duplicate exporter prevention: added a process_guard option to execute_ssh_command_nohup() that uses pgrep to skip launch if the exporter is already running, preventing orphan processes on SSH retry.
 
* VictoriaMetrics startup health check: added exponential backoff polling of the /ready endpoint after launching local VM to deal with occasional slow launch observed on Frontier/Lustre file systems.

* Query timing fix: updated logic capture full wallclock including CSV and PDF export, not just the VM query phase.
