### PR TITLE
Link hsa-runtime64 into the ROCProfiler-SDK extension

### DIFF
--- a/omnistat/collector_rocprofiler_sdk.py
+++ b/omnistat/collector_rocprofiler_sdk.py
@@ -50,8 +50,11 @@ from omnistat.collector_base import Collector
 
 try:
     from omnistat.rocprofiler_sdk_extension import get_samplers, initialize
-except ModuleNotFoundError as e:
-    logging.error(f"Missing ROCProfiler-SDK extension: build with installation required")
+except ModuleNotFoundError:
+    logging.error(f"ERROR: Missing ROCProfiler-SDK extension, build with installation required")
+    sys.exit(4)
+except ImportError as e:
+    logging.error(f"ERROR: Unable to load ROCProfiler-SDK extension, check ROCm installation and rebuild: {e}")
     sys.exit(4)
 
 SAMPLING_MODES = ["constant", "gpu-id", "periodic"]

--- a/rocprofiler-sdk/CMakeLists.txt
+++ b/rocprofiler-sdk/CMakeLists.txt
@@ -50,7 +50,8 @@ if (NOT BUILD_KERNEL_TRACE_LIB)
     find_package(rocprofiler-sdk REQUIRED)
 
     nanobind_add_module(rocprofiler_sdk_extension device.cpp binding.cpp)
-    target_link_libraries(rocprofiler_sdk_extension PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+    target_link_libraries(rocprofiler_sdk_extension PRIVATE rocprofiler-sdk::rocprofiler-sdk
+                                                            hsa-runtime64::hsa-runtime64)
 
     # Install the module to location within the Python package
     install(TARGETS rocprofiler_sdk_extension LIBRARY DESTINATION omnistat)

--- a/rocprofiler-sdk/device.cpp
+++ b/rocprofiler-sdk/device.cpp
@@ -169,9 +169,12 @@ std::vector<double> DeviceSampler::sample() {
                                                records_.data(), &size);
 
     // Aggregate counter records: sums all records from each counter in an
-    // attempt to return a value that represents total activity.
+    // attempt to return a value that represents total activity. Only the
+    // records written by this sample are aggregated: the rest of the buffer
+    // still holds the records of the previous one.
     rocprofiler_counter_id_t counter_id = {.handle = 0};
-    for (const auto& record : records_) {
+    for (size_t i = 0; i < size; i++) {
+        const auto& record = records_[i];
         rocprofiler_query_record_counter_id(record.id, &counter_id);
         aggregate[counter_id.handle] += record.counter_value;
     }


### PR DESCRIPTION
`device.cpp` calls `hsa_init()` directly, but the extension linked only rocprofiler-sdk, which exports HSA as a "nolink" target: it provides the headers without emitting a link. The symbol was resolved by accident,  through `librocprofiler-sdk` -> `libhsa-amd-aqlprofile64` -> `libhsa-runtime64`. rocprofiler-sdk 1.3.x compiles aqlprofile in and only dlopens the external library, so that NEEDED edge is gone and the module fails at import on ROCm 10.0.

Closes #328.