### PR TITLE
Add a library to enable counter collection

### DIFF
--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -47,9 +47,9 @@ jobs:
           cmake --build build/
           cmake --install build/ --prefix .
 
-      - name: Build kernel trace library
+      - name: Build kernel trace and counter libraries
         run: |
-          cmake -B build -S rocprofiler-sdk -DBUILD_KERNEL_TRACE_LIB=ON
+          cmake -B build -S rocprofiler-sdk -DBUILD_KERNEL_TRACE_LIB=ON -DBUILD_COUNT_LIB=ON
           cmake --build build
 
       - name: Build test workloads
@@ -57,9 +57,9 @@ jobs:
 
       - name: Collector tests
         env:
-          ROCP_TOOL_LIBRARIES: ${{ github.workspace }}/build/libomnistat_trace.so
-          # Workaround to make sure counters work when tracing is also enabled
-          HSA_TOOLS_ROCPROFILER_V1_TOOLS: 1
+          # Trailing colon is required: rocprofiler-sdk drops the last entry when
+          # parsing this variable, so the counter library would not be loaded.
+          ROCP_TOOL_LIBRARIES: "${{ github.workspace }}/build/libomnistat_trace.so:${{ github.workspace }}/build/libomnistat_count.so:"
         run: |
           source omnistat_venv/bin/activate
           srun -N 1 -J omnistat -p $CI_QUEUE -t 00:10:00 \

--- a/.github/workflows/test-mi325.yml
+++ b/.github/workflows/test-mi325.yml
@@ -72,9 +72,9 @@ jobs:
           cmake --build build/
           cmake --install build/ --prefix .
           
-      - name: Build kernel trace library
+      - name: Build kernel trace and counter libraries
         run: |
-          cmake -B build -S rocprofiler-sdk -DBUILD_KERNEL_TRACE_LIB=ON -DCMAKE_PREFIX_PATH=/opt/rocm
+          cmake -B build -S rocprofiler-sdk -DBUILD_KERNEL_TRACE_LIB=ON -DBUILD_COUNT_LIB=ON -DCMAKE_PREFIX_PATH=/opt/rocm
           cmake --build build
 
       - name: Build test workloads
@@ -82,11 +82,11 @@ jobs:
 
       - name: Collector tests
         env:
-          ROCP_TOOL_LIBRARIES: ${{ github.workspace }}/build/libomnistat_trace.so
           LD_LIBRARY_PATH: /opt/rocm/lib
-          # Workaround to make sure counters work when tracing is also enabled
-          HSA_TOOLS_ROCPROFILER_V1_TOOLS: 1
         run: |
+          # Trailing colon is required: rocprofiler-sdk drops the last entry when
+          # parsing this variable, so the counter library would not be loaded.
+          export ROCP_TOOL_LIBRARIES="$GITHUB_WORKSPACE/build/libomnistat_trace.so:$GITHUB_WORKSPACE/build/libomnistat_count.so:"
           source omnistat_venv/bin/activate
           su - ubuntu -c "sleep 300 &"
           pytest -s -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py test/test_external_collector.py

--- a/rocprofiler-sdk/CMakeLists.txt
+++ b/rocprofiler-sdk/CMakeLists.txt
@@ -32,32 +32,23 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()
 
-# The kernel tracing library is meant to be built separately from the Omnistat
-# package and extensions. When it's enabled, compile only the library and
-# nothing else.
+# The kernel tracing and counter enablement libraries are meant to be built
+# separately from the Omnistat package and extensions. Enabling either option
+# below builds only the corresponding libraries; they are independent and can be
+# enabled together.
 option(BUILD_KERNEL_TRACE_LIB "Build the kernel tracing library" OFF)
+option(BUILD_COUNT_LIB "Build the counter enablement library" OFF)
 
-if (NOT BUILD_KERNEL_TRACE_LIB)
-    find_package(Python COMPONENTS Interpreter Development REQUIRED)
-
-    set(CMAKE_EXECUTE_PROCESS_COMMAND_ECHO STDOUT)
-    execute_process(
-        COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
-        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
-
-    find_package(nanobind CONFIG REQUIRED)
-
+if (BUILD_KERNEL_TRACE_LIB OR BUILD_COUNT_LIB)
     find_package(rocprofiler-sdk REQUIRED)
+endif()
 
-    nanobind_add_module(rocprofiler_sdk_extension device.cpp binding.cpp)
-    target_link_libraries(rocprofiler_sdk_extension PRIVATE rocprofiler-sdk::rocprofiler-sdk
-                                                            hsa-runtime64::hsa-runtime64)
+if (BUILD_COUNT_LIB)
+    add_library(omnistat_count SHARED count_enable.cpp)
+    target_link_libraries(omnistat_count PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+endif()
 
-    # Install the module to location within the Python package
-    install(TARGETS rocprofiler_sdk_extension LIBRARY DESTINATION omnistat)
-else()
-    find_package(rocprofiler-sdk REQUIRED)
-
+if (BUILD_KERNEL_TRACE_LIB)
     include(FetchContent)
     include(CheckCXXSourceCompiles)
 
@@ -99,4 +90,24 @@ else()
         target_compile_definitions(omnistat_trace PRIVATE FMT_HEADER_ONLY)
         target_include_directories(omnistat_trace PRIVATE ${fmt_SOURCE_DIR}/include)
     endif()
+endif()
+
+if (NOT BUILD_KERNEL_TRACE_LIB AND NOT BUILD_COUNT_LIB)
+    find_package(Python COMPONENTS Interpreter Development REQUIRED)
+
+    set(CMAKE_EXECUTE_PROCESS_COMMAND_ECHO STDOUT)
+    execute_process(
+        COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+
+    find_package(nanobind CONFIG REQUIRED)
+
+    find_package(rocprofiler-sdk REQUIRED)
+
+    nanobind_add_module(rocprofiler_sdk_extension device.cpp binding.cpp)
+    target_link_libraries(rocprofiler_sdk_extension PRIVATE rocprofiler-sdk::rocprofiler-sdk
+                                                            hsa-runtime64::hsa-runtime64)
+
+    # Install the module to location within the Python package
+    install(TARGETS rocprofiler_sdk_extension LIBRARY DESTINATION omnistat)
 endif()

--- a/rocprofiler-sdk/count_enable.cpp
+++ b/rocprofiler-sdk/count_enable.cpp
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------------
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+// ---------------------------------------------------------------------------
+
+// Enables hardware counter collection for the queues of the application this
+// library is loaded into.
+//
+// ROCProfiler-SDK only makes an application's queues visible to hardware counter
+// collection when a counting service is registered in that process: queue setup
+// consults the registered contexts and, when any of them requests counters, emits
+// a packet enabling performance counting on the queue. Registration alone is
+// enough; the context is never started, so no counters are collected here.
+//
+// This reproduces what ROCProfiler v1 provided through HSA_TOOLS_LIB, and lets a
+// separate Omnistat exporter sample counters for this application without
+// requiring CAP_PERFMON. Load it into the application with:
+//
+//   ROCP_TOOL_LIBRARIES=/path/to/libomnistat_count.so
+//
+// Note that only queues of applications loading this library are counted; work
+// from other processes is not reflected in the values reported by the exporter.
+
+#include <rocprofiler-sdk/agent.h>
+#include <rocprofiler-sdk/device_counting_service.h>
+#include <rocprofiler-sdk/registration.h>
+#include <rocprofiler-sdk/rocprofiler.h>
+#include <rocprofiler-sdk/version.h>
+
+#include <iostream>
+
+#ifndef ROCPROFILER_SDK_VERSION
+#define ROCPROFILER_SDK_VERSION ROCPROFILER_VERSION
+#endif
+
+namespace {
+
+rocprofiler_context_id_t context = {};
+rocprofiler_agent_id_t agent = {};
+
+// A device counting service is used rather than a dispatch counting service:
+// both enable counters, but registering a dispatch service also makes
+// ROCProfiler-SDK replace the application's queues, which silently discards the
+// CU masks and priorities they were created with.
+rocprofiler_status_t find_agent(rocprofiler_agent_version_t, const void** agents, size_t count,
+                                void*) {
+    for (size_t i = 0; i < count; i++) {
+        const auto* candidate = static_cast<const rocprofiler_agent_v0_t*>(agents[i]);
+        if (candidate->type == ROCPROFILER_AGENT_TYPE_GPU && agent.handle == 0) {
+            agent = candidate->id;
+        }
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+// Required to register the service, but never invoked: the context is left inactive.
+void device_callback(rocprofiler_context_id_t, rocprofiler_agent_id_t,
+                     rocprofiler_device_counting_agent_cb_t, void*) {
+}
+
+// Failures are reported but never raised: this library is loaded into a user's
+// application, and being unable to enable counters is not a reason to disrupt it.
+int tool_init(rocprofiler_client_finalize_t, void*) {
+    rocprofiler_status_t status = rocprofiler_create_context(&context);
+    if (status != ROCPROFILER_STATUS_SUCCESS) {
+        std::cerr << "Omnistat: counters disabled (unable to create context: "
+                  << rocprofiler_get_status_string(status) << ")" << std::endl;
+        return -1;
+    }
+
+    rocprofiler_query_available_agents(ROCPROFILER_AGENT_INFO_VERSION_0, find_agent,
+                                       sizeof(rocprofiler_agent_v0_t), nullptr);
+    if (agent.handle == 0) {
+        std::cerr << "Omnistat: counters disabled (no GPU agent found)" << std::endl;
+        return -1;
+    }
+
+    status = rocprofiler_configure_device_counting_service(context, rocprofiler_buffer_id_t{0},
+                                                           agent, device_callback, nullptr);
+    if (status != ROCPROFILER_STATUS_SUCCESS) {
+        std::cerr << "Omnistat: counters disabled (unable to configure counting service: "
+                  << rocprofiler_get_status_string(status) << ")" << std::endl;
+        return -1;
+    }
+
+    // Reported unconditionally: an application that fails to load this library
+    // collects no counters and reports no error, so this is the only indication
+    // that counters are being collected for this process.
+    std::cerr << "Omnistat: counters enabled" << std::endl;
+    return 0;
+}
+
+void tool_fini(void*) {
+}
+
+} // namespace
+
+extern "C" rocprofiler_tool_configure_result_t*
+rocprofiler_configure(uint32_t version, const char* runtime_version,
+                      uint32_t priority [[maybe_unused]], rocprofiler_client_id_t* id) {
+    constexpr uint32_t compiled_version = ROCPROFILER_SDK_VERSION;
+
+    if (version / 10000 != compiled_version / 10000) {
+        std::cerr << "Omnistat: counters disabled (version mismatch, compiled against "
+                  << compiled_version / 10000 << "." << (compiled_version % 10000) / 100 << "."
+                  << compiled_version % 100 << " but runtime is "
+                  << (runtime_version ? runtime_version : "unknown") << ")" << std::endl;
+        return nullptr;
+    }
+
+    id->name = "omnistat-counters";
+
+    static auto cfg = rocprofiler_tool_configure_result_t{
+        sizeof(rocprofiler_tool_configure_result_t), &tool_init, &tool_fini, nullptr};
+
+    return &cfg;
+}

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -42,6 +42,11 @@ from omnistat.monitor import Monitor
 from omnistat.node_monitoring import OmnistatServer
 from omnistat.utils import runShellCommand
 
+requires_counters = pytest.mark.skipif(
+    not test.config.rocm_host or "ROCP_TOOL_LIBRARIES" not in os.environ,
+    reason="requires ROCm and ROCP_TOOL_LIBRARIES",
+)
+
 # fmt: off
 SMI_METRICS = [
     {"name":"rocm_num_gpus",                                "validate":">=1",                "labels":None},
@@ -435,7 +440,7 @@ class TestCollectors:
 
 
 class TestHardwareCounters:
-    @pytest.mark.skipif(not test.config.rocm_host, reason="requires ROCm")
+    @requires_counters
     @pytest.mark.skipif("Radeon" in gpu_type, reason="hardware counters not supported on RDNA4")
     def test_counters_with_workload(self):
         config_sections = {
@@ -448,10 +453,9 @@ class TestHardwareCounters:
         server = OmnistatTestServer(["rocprofiler"], config_sections=config_sections)
 
         try:
-            # Run GPU workload with HSA_TOOLS_LIB so the profiler can intercept
-            # application-level PMC counter activity.
-            hsa_tools_lib = os.path.join(test.config.rocm_path, "lib", "librocprofiler64.so")
-            result = workloads.run("vector_add", [1000000], env={"HSA_TOOLS_LIB": hsa_tools_lib})
+            # Run GPU workload with the tool libraries from the environment, which
+            # must include the counter enablement library.
+            result = workloads.run("vector_add", [1000000])
             assert result.returncode == 0, f"vector_add failed: {result.stderr}"
 
             # Scrape metrics, keyed by (card, counter_name)


### PR DESCRIPTION
ROCprofiler v1 is no longer shipped with ROCm 10. `librocprofiler64.so` and `librocprofiler64v2.so` are absent, and there is no rocprofiler package in the repository.

Collecting counters from a separate process requires the application's queues to have `COMPUTE_PERFCOUNT_ENABLE` set; waves from a queue  without it are invisible to the SQ counter blocks. v1 set that bit from inside the application, unprivileged, by intercepting queue creation, which is
  exactly what `HSA_TOOLS_LIB=librocprofiler64.so` was doing in our tests and docs. The `HSA_TOOLS_LIB` hook still exists in ROCr, but there is no longer a library   to point it at.

This PR provides  `libomnistat_count.so` (`-DBUILD_COUNT_LIB=ON`), a small tool library taking the unprivileged route above. It registers a counting service and deliberately never starts it, so the application's queues report counters to a separate Omnistat collector with no capability required on the job other than setting the following variable:
```
  ROCP_TOOL_LIBRARIES=/path/to/libomnistat_count.so
```