### PR TITLE
Do not check the sclk clock metric on consumer GPUs

### DIFF
--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -55,7 +55,6 @@ SMI_METRICS = [
     {"name":"rocm_average_socket_power_watts",              "validate":">=10",               "labels":["card"],         "hardware":["Instinct"]},
     {"name":"rocm_average_socket_power_watts",              "validate":">0",                 "labels":["card"],         "hardware":["Radeon"]},
     {"name":"rocm_sclk_clock_mhz",                          "validate":">=90" ,              "labels":["card"],         "hardware":["Instinct"]},
-    {"name":"rocm_sclk_clock_mhz",                          "validate":">=0",                "labels":["card"],         "hardware":["Radeon"]},
     {"name":"rocm_mclk_clock_mhz",                          "validate":">=90",               "labels":["card"],         "hardware":["Instinct"]},
     {"name":"rocm_mclk_clock_mhz",                          "validate":">=0",                "labels":["card"],         "hardware":["Radeon"]},
     {"name":"rocm_vram_total_bytes",                        "validate":">1073741824",        "labels":["card"]},


### PR DESCRIPTION
`rocm_sclk_clock_mhz` not always present on consumer GPUs.