### PR TITLE
update fmt version to accommodate newer rocm clang versions

### DIFF
--- a/rocprofiler-sdk/CMakeLists.txt
+++ b/rocprofiler-sdk/CMakeLists.txt
@@ -83,7 +83,7 @@ if (BUILD_KERNEL_TRACE_LIB)
         message(STATUS "std::format not available, using fmt library")
         FetchContent_Declare(
             fmt
-            URL https://github.com/fmtlib/fmt/archive/refs/tags/11.0.2.tar.gz
+            URL https://github.com/fmtlib/fmt/archive/refs/tags/11.1.0.tar.gz
             DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         )
         FetchContent_MakeAvailable(fmt)


### PR DESCRIPTION
This PR updates the `fmt` package used with with rocprofiler-sdk for kernel tracing from `11.0.2` to `11.1.0`.  Needed for newer ROCm versions to avoid build failures with newer clang.  Observed initially on Lux and this change allows successful builds against rocm/7.14.0 on that system.